### PR TITLE
Various pom.xml fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,45 @@
   <groupId>com.oracle.database.r2dbc</groupId>
   <artifactId>oracle-r2dbc</artifactId>
   <version>0.1.0</version>
+  <name>oracle-r2dbc</name>
+  <description>
+    Oracle R2DBC Driver implementing version 0.8.2 of the R2DBC SPI for Oracle Database.
+  </description>
+  <url>
+    https://github.com/oracle/oracle-r2dbc
+  </url>
+  <inceptionYear>2019</inceptionYear>
+  <licenses>
+    <license>
+      <name>Universal Permissive License v1.0</name>
+      <url>https://opensource.org/licenses/UPL</url>
+    </license>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+  <developers>
+    <developer>
+      <organization>Oracle America, Inc.</organization>
+      <organizationUrl>http://www.oracle.com</organizationUrl>
+    </developer>
+  </developers>
+  <scm>
+    <url>https://github.com/oracle/oracle-r2dbc.git</url>
+    <connection>
+      scm:git:https://github.com/oracle/oracle-r2dbc.git
+    </connection>
+    <developerConnection>scm:git:git@github.com:oracle/oracle-r2dbc.git</developerConnection>
+  </scm>
+  <issueManagement>
+    <system>GitHub</system>
+    <url>https://github.com/oracle/oracle-r2dbc/issues</url>
+  </issueManagement>
 
   <properties>
     <java.version>11</java.version>
+    <ojdbc.version>21.1.0.0</ojdbc.version>
     <r2dbc.version>0.8.2.RELEASE</r2dbc.version>
     <reactor.version>3.3.0.RELEASE</reactor.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
@@ -52,14 +88,13 @@
             <arg>-Xlint:-serial</arg>
           </compilerArgs>
           <showWarnings>true</showWarnings>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.1</version>
+        <version>3.2.0</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -87,13 +122,33 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>3.2.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
+        <version>3.0.0-M1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-install-plugin</artifactId>
+        <version>3.0.0-M1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.2.0</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>3.0.0-M5</version>
         <configuration>
           <includes>
             <include>**/*Test.java</include>
@@ -131,16 +186,7 @@
         </configuration>
       </plugin>
     </plugins>
-    <directory>${project.basedir}/target</directory>
-    <outputDirectory>${project.build.directory}/classes</outputDirectory>
-    <finalName>${project.artifactId}-${project.version}</finalName>
-    <testOutputDirectory>${project.build.directory}/test-classes</testOutputDirectory>
-    <sourceDirectory>${project.basedir}/src/main/java</sourceDirectory>
-    <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
     <resources>
-      <resource>
-        <directory>${project.basedir}/src/main/resources</directory>
-      </resource>
       <resource>
         <directory>${project.basedir}</directory>
         <includes>
@@ -151,11 +197,6 @@
         <targetPath>META-INF</targetPath>
       </resource>
     </resources>
-    <testResources>
-      <testResource>
-        <directory>${project.basedir}/src/test/resources</directory>
-      </testResource>
-    </testResources>
   </build>
 
   <dependencies>
@@ -168,7 +209,7 @@
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
       <artifactId>ojdbc11</artifactId>
-      <version>21.1.0.0</version>
+      <version>${ojdbc.version}</version>
     </dependency>
     <dependency>
       <groupId>io.projectreactor</groupId>
@@ -214,6 +255,51 @@
     </dependency>
 
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>publication</id>
+      <activation>
+        <property>
+          <name>release</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <attach>true</attach>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+                <configuration>
+                  <attach>true</attach>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>
 


### PR DESCRIPTION
This branch makes various improvements to the pom.xml file:
- Declaring plugin versions so that builds are consistent with different versions of maven
- Adds metadata for the project: name, description, url, etc
- Adds a "publication" profile that, when enabled, will generate javadoc and sources jar files during the package phase. This profile is intended to be used when publishing artifacts to Maven Central.

Also, shout out to @aalmiray for contributing a tremendous amount his knowledge and time while guiding me through these changes!