### PR TITLE
Include META-INF/services in jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,13 @@
         </includes>
         <targetPath>META-INF</targetPath>
       </resource>
+      <resource>
+        <directory>${project.basedir}/src/main/resources/META-INF/services/</directory>
+        <includes>
+          <include>io.r2dbc.spi.ConnectionFactoryProvider</include>
+        </includes>
+        <targetPath>META-INF/services/</targetPath>
+      </resource>
     </resources>
   </build>
 


### PR DESCRIPTION
Fix for Issue #10
Changes to pom.xml have the Oracle R2DBC jar include a META-INF/services/io.r2dbc.spi.ConnectionFactoryProvider file. 
This allows Oracle R2DBC's ConnectionFactory to be discovered using java.util.ServiceLoader when the jar is deployed on the class path rather than the module path.