### PR TITLE
11 Result.getRowsUpdated() Emits 0

### DIFF
--- a/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
@@ -68,17 +68,21 @@ abstract class OracleResultImpl implements Result {
 
   /**
    * Creates a {@code Result} that publishes either an empty stream of row
-   * data, or publishes an {@code updateCount} if it is greater than zero. An
-   * {@code updateCount} less than 1 is published as an empty stream.
+   * data, or publishes an {@code updateCount} if it is greater than or equal
+   * to zero. An {@code updateCount} less than zero is published as an empty
+   * stream.
    * @param updateCount Update count to publish
    * @return An update count {@code Result}
    */
   public static Result createUpdateCountResult(int updateCount) {
     return new OracleResultImpl() {
 
+      final Publisher<Integer> updateCountPublisher =
+        updateCount < 0 ? Mono.empty() : Mono.just(updateCount);
+
       @Override
       Publisher<Integer> publishUpdateCount() {
-        return updateCount < 1 ? Mono.empty() : Mono.just(updateCount);
+        return updateCountPublisher;
       }
 
       @Override

--- a/src/test/java/oracle/r2dbc/impl/OracleResultImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleResultImplTest.java
@@ -98,13 +98,13 @@ public class OracleResultImplTest {
         // Expect update count publisher to support multiple subscribers
         awaitOne(1, insertCountPublisher1);
 
-        // Expect no update count from UPDATE of zero rows
+        // Expect an update count of zero from UPDATE of zero rows
         Result noUpdateResult = awaitOne(connection.createStatement(
           "UPDATE testGetRowsUpdated SET y = 99 WHERE x = 99")
           .execute());
         Publisher<Integer> noUpdateCountPublisher =
           noUpdateResult.getRowsUpdated();
-        awaitNone(noUpdateCountPublisher);
+        awaitOne(0, noUpdateCountPublisher);
 
         // Expect IllegalStateException from multiple Result consumptions.
         assertThrows(IllegalStateException.class,
@@ -112,7 +112,7 @@ public class OracleResultImplTest {
         assertThrows(IllegalStateException.class, noUpdateResult::getRowsUpdated);
 
         // Expect update count publisher to support multiple subscribers
-        awaitNone(noUpdateCountPublisher);
+        awaitOne(0, noUpdateCountPublisher);
 
         // Expect update count of 2 from UPDATE of 2 rows
         Result updateResult = awaitOne(connection.createStatement(

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -745,11 +745,9 @@ public class OracleStatementImplTest {
     Connection connection =
       Mono.from(sharedConnection()).block(connectTimeout());
     try {
-      // Expect DDL to result in no update count
-      awaitUpdate(
-        Collections.emptyList(),
-        connection.createStatement(
-          "CREATE TABLE testExecute (x NUMBER)"));
+      // Expect DDL to result in an update count of zero
+      awaitUpdate(0, connection.createStatement(
+        "CREATE TABLE testExecute (x NUMBER)"));
       // Expect DDL to result in no row data
       awaitQuery(
         Collections.emptyList(),

--- a/src/test/java/oracle/r2dbc/util/Awaits.java
+++ b/src/test/java/oracle/r2dbc/util/Awaits.java
@@ -132,16 +132,12 @@ public final class Awaits {
   /**
    * Executes a {@code statement} and blocks until the execution
    * completes. This method verifies that the execution produces a
-   * {@link Result} with no count of updated rows.
-   * @param statement A statement that does not update rows.
+   * {@link Result} with a count of zero updated rows.
+   * @param statement A statement that does updates zero rows.
    * @throws Throwable If the statement execution results in an error.
    */
   public static void awaitExecution(Statement statement) {
-    assertNull(
-      Mono.from(statement.execute())
-        .flatMap(result -> Mono.from(result.getRowsUpdated()))
-        .block(sqlTimeout()),
-      "Expected no update count when not updating rows");
+    awaitUpdate(0, statement);
   }
 
   /**


### PR DESCRIPTION
Fix for Issue #11 
When a SQL command updates zero rows, the Result for that command will emit an update count of zero. This changes existing behavior implemented for that API, where a Publisher would emit only onComplete if the update count were zero.

The value of 0 is now emitted in the following cases:
1) DML commands that update zero rows, such as an UPDATE with a WHERE clause satisfied by zero rows.
2) DDL commands, such as CREATE TABLE

The behavior does not change for SQL query (SELECT) commands. For commands that return row data, the getRowsUpdated() Publisher emits no value.