### PR TITLE
Convert connectTimeout to seconds correctly

### DIFF
--- a/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
@@ -68,8 +68,6 @@ import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
 import static io.r2dbc.spi.ConnectionFactoryOptions.CONNECT_TIMEOUT;
 import static io.r2dbc.spi.ConnectionFactoryOptions.SSL;
 
-import static java.sql.Statement.RETURN_GENERATED_KEYS;
-
 import static oracle.r2dbc.impl.OracleR2dbcExceptions.getOrHandleSQLException;
 import static oracle.r2dbc.impl.OracleR2dbcExceptions.runOrHandleSQLException;
 import static oracle.r2dbc.impl.OracleR2dbcExceptions.toR2dbcException;
@@ -490,7 +488,7 @@ final class OracleReactiveJdbcAdapter implements ReactiveJdbcAdapter {
         oracleDataSource.setLoginTimeout(
           Math.toIntExact(timeout.getSeconds())
             // Round up to nearest whole second
-            + timeout.getNano() == 0 ? 0 : 1));
+            + (timeout.getNano() == 0 ? 0 : 1)));
     }
 
   }

--- a/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
@@ -322,7 +322,19 @@ public class OracleReactiveJdbcAdapterTest {
 
       verifyConnectTimeout(listeningChannel, ConnectionFactoryOptions.parse(
         "r2dbc:oracle://localhost:" + listeningChannel.socket().getLocalPort()
-          + "?connectTimeout=PT1S")); // The value is parsed as a Duration
+          + "?connectTimeout=PT2S")); // The value is parsed as a Duration
+
+      verifyConnectTimeout(listeningChannel, ConnectionFactoryOptions.builder()
+        .option(DRIVER, "oracle")
+        .option(HOST, "localhost")
+        .option(PORT, listeningChannel.socket().getLocalPort())
+        .option(DATABASE, serviceName())
+        .option(CONNECT_TIMEOUT, Duration.ofMillis(500))
+        .build());
+
+      verifyConnectTimeout(listeningChannel, ConnectionFactoryOptions.parse(
+        "r2dbc:oracle://localhost:" + listeningChannel.socket().getLocalPort()
+          + "?connectTimeout=PT0.5S")); // The value is parsed as a Duration
     }
   }
 


### PR DESCRIPTION
Fixes a bug when converting a connectTimeout Duration into seconds. This bug would set 1 second as a connection timeout, regardless of what the Duration had.
