### PR TITLE
Executor Option

### DIFF
--- a/sample/src/main/java/oracle/r2dbc/samples/DescriptorURL.java
+++ b/sample/src/main/java/oracle/r2dbc/samples/DescriptorURL.java
@@ -23,7 +23,7 @@ package oracle.r2dbc.samples;
 
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactoryOptions;
-import io.r2dbc.spi.Option;
+import oracle.r2dbc.OracleR2dbcOptions;
 import reactor.core.publisher.Mono;
 
 import static oracle.r2dbc.samples.DatabaseConfig.HOST;
@@ -47,7 +47,8 @@ public class DescriptorURL {
 
   /**
    * A TNS descriptor specifying the HOST, PORT, and SERVICE_NAME read from
-   * {@link DatabaseConfig}.
+   * {@link DatabaseConfig}. These values can be configured in a
+   * config.properties file of the current directory.
    */
   private static final String DESCRIPTOR = "(DESCRIPTION=" +
     "(ADDRESS=(HOST="+HOST+")(PORT="+PORT+")(PROTOCOL=tcp))" +
@@ -55,7 +56,7 @@ public class DescriptorURL {
 
   public static void main(String[] args) {
     // A descriptor may appear in the query section of an R2DBC URL:
-    String r2dbcUrl = "r2dbc:oracle://?oracleNetDescriptor="+DESCRIPTOR;
+    String r2dbcUrl = "r2dbc:oracle://?oracle.r2dbc.descriptor="+DESCRIPTOR;
     Mono.from(ConnectionFactories.get(ConnectionFactoryOptions.parse(r2dbcUrl)
       .mutate()
       .option(ConnectionFactoryOptions.USER, USER)
@@ -67,7 +68,7 @@ public class DescriptorURL {
           "SELECT 'Connected with TNS descriptor' FROM sys.dual")
           .execute())
           .flatMapMany(result ->
-            result.map((row, metadata) -> row.get(0, String.class)))
+            result.map(row -> row.get(0, String.class)))
           .concatWith(Mono.from(connection.close()).cast(String.class)))
       .toStream()
       .forEach(System.out::println);
@@ -75,7 +76,7 @@ public class DescriptorURL {
     // A descriptor may also be specified as an Option
     Mono.from(ConnectionFactories.get(ConnectionFactoryOptions.builder()
       .option(ConnectionFactoryOptions.DRIVER, "oracle")
-      .option(Option.valueOf("oracleNetDescriptor"), DESCRIPTOR)
+      .option(OracleR2dbcOptions.DESCRIPTOR, DESCRIPTOR)
       .option(ConnectionFactoryOptions.USER, USER)
       .option(ConnectionFactoryOptions.PASSWORD, PASSWORD)
       .build())

--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -35,7 +35,9 @@ public final class OracleR2dbcOptions {
 
   /**
    * Extended {@code Option} that specifies an Oracle Net Connect Descriptor
-   * of the form "(DESCRIPTION=...)"
+   * of the form "(DESCRIPTION=...)". If {@link #TNS_ADMIN} is specified,
+   * then the value of this {@code Option} may be set to a tnsnames.ora
+   * alias.
    */
   public static final Option<CharSequence> DESCRIPTOR =
     Option.valueOf("oracle.r2dbc.descriptor");

--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -1,0 +1,224 @@
+/*
+  Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+
+  This software is dual-licensed to you under the Universal Permissive License
+  (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License
+  2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+  either license.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+package oracle.r2dbc;
+
+import io.r2dbc.spi.Option;
+import oracle.jdbc.OracleConnection;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ForkJoinPool;
+
+/**
+ * Extended {@link Option}s supported by the Oracle R2DBC Driver.
+ */
+public final class OracleR2dbcOptions {
+
+  private OracleR2dbcOptions() {}
+
+  /**
+   * Extended {@code Option} that specifies an Oracle Net Connect Descriptor
+   * of the form "(DESCRIPTION=...)"
+   */
+  public static final Option<CharSequence> DESCRIPTOR =
+    Option.valueOf("oracle.r2dbc.descriptor");
+
+  /**
+   * Extended {@code Option} that specifies an {@link Executor} for executing
+   * asynchronous tasks. This {@code Option} can not be configured in the
+   * query section of an R2DBC URL, it must be configured programmatically,
+   * as in:
+   * <pre>
+   * Executor myExecutor = getMyExecutor();
+   *
+   * ConnectionFactoryOptions options = ConnectionFactoryOptions.builder()
+   *   .option(ConnectionFactoryOptions.DRIVER, "oracle")
+   *   .option(OracleR2dbcOptions.EXECUTOR, myExecutor)
+   *   ...
+   *   .build();
+   * </pre>
+   * If this option is not configured, then Oracle R2DBC will use
+   * {@code ForkJoinPool}'s
+   * {@linkplain ForkJoinPool#commonPool() common pool} by default.
+   */
+  public static final Option<Executor> EXECUTOR =
+    Option.valueOf("oracle.r2dbc.executor");
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_TNS_ADMIN}
+   */
+  public static final Option<CharSequence> TNS_ADMIN =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_TNS_ADMIN);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_WALLET_LOCATION}
+   */
+  public static final Option<CharSequence> TLS_WALLET_LOCATION =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_WALLET_LOCATION);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_WALLET_PASSWORD}
+   */
+  public static final Option<CharSequence> TLS_WALLET_PASSWORD =
+    Option.sensitiveValueOf(OracleConnection.CONNECTION_PROPERTY_WALLET_PASSWORD);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORE}
+   */
+  public static final Option<CharSequence> TLS_KEYSTORE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORETYPE}
+   */
+  public static final Option<CharSequence> TLS_KEYSTORE_TYPE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORETYPE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTOREPASSWORD}
+   */
+  public static final Option<CharSequence> TLS_KEYSTORE_PASSWORD =
+    Option.sensitiveValueOf(OracleConnection.CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTOREPASSWORD);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORE}
+   */
+  public static final Option<CharSequence> TLS_TRUSTSTORE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORETYPE}
+   */
+  public static final Option<CharSequence> TLS_TRUSTSTORE_TYPE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORETYPE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTOREPASSWORD}
+   */
+  public static final Option<CharSequence> TLS_TRUSTSTORE_PASSWORD =
+    Option.sensitiveValueOf(OracleConnection.CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTOREPASSWORD);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_SERVICES}
+   */
+  public static final Option<CharSequence> AUTHENTICATION_SERVICES =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_SERVICES);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_SSL_CERTIFICATE_ALIAS}
+   */
+  public static final Option<CharSequence> TLS_CERTIFICATE_ALIAS =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_SSL_CERTIFICATE_ALIAS);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_SSL_SERVER_DN_MATCH}
+   */
+  public static final Option<CharSequence> TLS_SERVER_DN_MATCH =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_SSL_SERVER_DN_MATCH);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_SSL_SERVER_CERT_DN}
+   */
+  public static final Option<CharSequence> TLS_SERVER_CERT_DN =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_SSL_SERVER_CERT_DN);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_SSL_VERSION}
+   */
+  public static final Option<CharSequence> TLS_VERSION =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_SSL_VERSION);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_SSL_CIPHER_SUITES}
+   */
+  public static final Option<CharSequence> TLS_CIPHER_SUITES =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_SSL_CIPHER_SUITES);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_SSL_KEYMANAGERFACTORY_ALGORITHM}
+   */
+  public static final Option<CharSequence> TLS_KEYMANAGERFACTORY_ALGORITHM =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_SSL_KEYMANAGERFACTORY_ALGORITHM);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_SSL_TRUSTMANAGERFACTORY_ALGORITHM}
+   */
+  public static final Option<CharSequence> TLS_TRUSTMANAGERFACTORY_ALGORITHM =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_SSL_TRUSTMANAGERFACTORY_ALGORITHM);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_SSL_CONTEXT_PROTOCOL}
+   */
+  public static final Option<CharSequence> SSL_CONTEXT_PROTOCOL =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_SSL_CONTEXT_PROTOCOL);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_FAN_ENABLED}
+   */
+  public static final Option<CharSequence> FAN_ENABLED =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_FAN_ENABLED);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_IMPLICIT_STATEMENT_CACHE_SIZE}
+   */
+  public static final Option<CharSequence> IMPLICIT_STATEMENT_CACHE_SIZE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_IMPLICIT_STATEMENT_CACHE_SIZE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_DEFAULT_LOB_PREFETCH_SIZE}
+   */
+  public static final Option<CharSequence> DEFAULT_LOB_PREFETCH_SIZE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_DEFAULT_LOB_PREFETCH_SIZE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_NET_DISABLE_OUT_OF_BAND_BREAK}
+   */
+  public static final Option<CharSequence> DISABLE_OUT_OF_BAND_BREAK =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_NET_DISABLE_OUT_OF_BAND_BREAK);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_ENABLE_QUERY_RESULT_CACHE}
+   */
+  public static final Option<CharSequence> ENABLE_QUERY_RESULT_CACHE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_ENABLE_QUERY_RESULT_CACHE);
+}

--- a/src/main/java/oracle/r2dbc/impl/ReactiveJdbcAdapter.java
+++ b/src/main/java/oracle/r2dbc/impl/ReactiveJdbcAdapter.java
@@ -38,6 +38,7 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 /**
@@ -124,6 +125,8 @@ interface ReactiveJdbcAdapter {
    * Publishes a single JDBC {@link Connection} to a single subscriber. The
    * connection is established as if by invoking
    * {@link DataSource#getConnection()} on the specified {@code dataSource}.
+   * The {@code Connection} is configured to execute asynchronous tasks using
+   * the provided {@code executor}.
    * </p><p>
    * The {@code dataSource} is retained by the returned publisher, meaning
    * that any mutable state of the {@code dataSource} can affect the behavior
@@ -144,10 +147,12 @@ interface ReactiveJdbcAdapter {
    * </p>
    * @param dataSource JDBC data source that is configured to establish a
    *   connection. Not null.
+   * @param executor Executor to use for executing asynchronous tasks. Not null.
    * @return A publisher that emits a JDBC connection. Not null.
    * @throws R2dbcException If a database access error occurs.
    */
-  Publisher<? extends Connection> publishConnection(DataSource dataSource)
+  Publisher<? extends Connection> publishConnection(
+    DataSource dataSource, Executor executor)
     throws R2dbcException;
 
   /**

--- a/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
@@ -220,13 +220,13 @@ public class OracleReactiveJdbcAdapterTest {
       // Expect to connect with the descriptor in the R2DBC URL
       awaitNone(awaitOne(
         ConnectionFactories.get(String.format(
-          "r2dbc:oracle://%s:%s@?oracleNetDescriptor=%s",
+          "r2dbc:oracle://%s:%s@?oracle.r2dbc.descriptor=%s",
           user(), password(), descriptor))
           .create())
         .close());
       awaitNone(awaitOne(
         ConnectionFactories.get(ConnectionFactoryOptions.parse(String.format(
-          "r2dbc:oracle://@?oracleNetDescriptor=%s", descriptor))
+          "r2dbc:oracle://@?oracle.r2dbc.descriptor=%s", descriptor))
           .mutate()
           .option(USER, user())
           .option(PASSWORD, password())
@@ -238,14 +238,14 @@ public class OracleReactiveJdbcAdapterTest {
       // the file path and an alias
       awaitNone(awaitOne(
         ConnectionFactories.get(String.format(
-          "r2dbc:oracle://%s:%s@?oracleNetDescriptor=%s&TNS_ADMIN=%s",
+          "r2dbc:oracle://%s:%s@?oracle.r2dbc.descriptor=%s&TNS_ADMIN=%s",
           user(), password(), "test_alias", userDir))
           .create())
           .close());
       awaitNone(awaitOne(
         ConnectionFactories.get(ConnectionFactoryOptions.parse(
           String.format(
-            "r2dbc:oracle://@?oracleNetDescriptor=%s&TNS_ADMIN=%s",
+            "r2dbc:oracle://@?oracle.r2dbc.descriptor=%s&TNS_ADMIN=%s",
             "test_alias", userDir))
           .mutate()
           .option(USER, user())
@@ -258,25 +258,25 @@ public class OracleReactiveJdbcAdapterTest {
       // are provided with a descriptor
       assertThrows(IllegalArgumentException.class, () ->
         ConnectionFactories.get(
-          "r2dbc:oracle://"+host()+"?oracleNetDescriptor="+descriptor));
+          "r2dbc:oracle://"+host()+"?oracle.r2dbc.descriptor="+descriptor));
       assertThrows(IllegalArgumentException.class, () ->
         ConnectionFactories.get("r2dbc:oracle://"
-            +host()+":"+port()+"?oracleNetDescriptor="+descriptor));
+            +host()+":"+port()+"?oracle.r2dbc.descriptor="+descriptor));
       assertThrows(IllegalArgumentException.class, () ->
         ConnectionFactories.get("r2dbc:oracle://"+host()+":"+port()+"/"
-          +serviceName()+"?oracleNetDescriptor="+descriptor));
+          +serviceName()+"?oracle.r2dbc.descriptor="+descriptor));
       assertThrows(IllegalArgumentException.class, () ->
         ConnectionFactories.get("r2dbc:oracle://"+host()+"/"
-          +serviceName()+"?oracleNetDescriptor="+descriptor));
+          +serviceName()+"?oracle.r2dbc.descriptor="+descriptor));
       assertThrows(IllegalArgumentException.class, () ->
         ConnectionFactories.get("r2dbc:oracle:///"
-            +serviceName()+"?oracleNetDescriptor="+descriptor));
+            +serviceName()+"?oracle.r2dbc.descriptor="+descriptor));
       assertThrows(IllegalArgumentException.class, () ->
         ConnectionFactories.get("r2dbcs:oracle://" + // r2dbcs is SSL=true
-          "?oracleNetDescriptor="+descriptor));
+          "?oracle.r2dbc.descriptor="+descriptor));
       assertThrows(IllegalArgumentException.class, () ->
         ConnectionFactories.get(
-          "r2dbc:oracle://?oracleNetDescriptor="+descriptor+"&ssl=true"));
+          "r2dbc:oracle://?oracle.r2dbc.descriptor="+descriptor+"&ssl=true"));
 
       // Create an ojdbc.properties file containing the user name
       Files.writeString(Path.of("ojdbc.properties"),
@@ -288,7 +288,7 @@ public class OracleReactiveJdbcAdapterTest {
         // specifies a user, and a standard option specifies the password.
         awaitNone(awaitOne(
           ConnectionFactories.get(ConnectionFactoryOptions.parse(String.format(
-            "r2dbc:oracle://?oracleNetDescriptor=%s&TNS_ADMIN=%s",
+            "r2dbc:oracle://?oracle.r2dbc.descriptor=%s&TNS_ADMIN=%s",
             "test_alias", userDir))
             .mutate()
             .option(PASSWORD, password())

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -2126,10 +2126,11 @@ public class OracleStatementImplTest {
         .boxed()
         .collect(Collectors.toList());
 
-      awaitMany(IntStream.range(0, publishers.length)
+      awaitOne(IntStream.range(0, publishers.length)
         .mapToObj(i -> expected)
-        .collect(Collectors.toList()),
-        Flux.merge(fetchPublishers));
+        .collect(Collectors.toSet()),
+        Flux.merge(fetchPublishers)
+          .collect(Collectors.toSet()));
     }
     finally {
       tryAwaitExecution(connection.createStatement(
@@ -2203,7 +2204,7 @@ public class OracleStatementImplTest {
       // drop table command executes. Set a DDL wait timeout to avoid a
       // "Resource busy..." error from the database.
       tryAwaitExecution(connection.createStatement(
-        "ALTER SESSION SET ddl_lock_wait_timeout=15"));
+        "ALTER SESSION SET ddl_lock_timeout=15"));
       tryAwaitExecution(connection.createStatement(
         "DROP TABLE testUsingWhenCancel"));
       tryAwaitNone(connection.close());


### PR DESCRIPTION
This branch adds an extended Option to configure a non-default Executor for asynchronous tasks that the driver executes. Oracle R2DBC implements support for this Option using Oracle JDBC's Reactive Extensions method: OracleConnectionBuilder.executorOracle(Executor).

This branch also moves all extended Options into a new OracleR2dbcOptions class that is exported to user code. This allows user code to reference a static field when setting an Option, like this:
```java
ConnectionFactoryOptions.builder()
  .option(OracleR2dbcOptions.EXECUTOR, myExecutor)
  .option(OracleR2dbcOptions.TNS_ADMIN, "/path/to/tns/admin")
  ...
```
Having a static field can be less error prone than having to type a String value with Option.valueOf(String). It also helps readers of the code to identify that the Option is one defined by Oracle R2DBC; This might not be as obvious with a call to Option.valueOf(String).

**This branch breaks existing code that used the "oracleNetDescriptor" option**
The Option has been renamed to "oracle.r2dbc.descriptor". Existing code will have to replace the old name with this new one. Since we are still in version 0.x, we are still breaking stuff (and trying our best to "move fast"). 
(@razum90, who originally requested support for descriptors. I'm "@"ing you just to be sure you'll see this change coming).

All Oracle R2DBC options going forward should use the "oracle.r2dbc" namespace. This is more consistent with other Java libraries from Oracle, such as Oracle JDBC, which uses the "oracle.jdbc" name space.

