### PR TITLE
WIP: Oracle Database 21.3 XE Test Action 

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,11 +51,19 @@ jobs:
         java-version: 11
     - name: Build with Maven
       run: mvn -B package --file pom.xml -DskipTests=true
-  # Tests the Oracle R2DBC Driver with an Oracle Database
-  test:
+  # Tests the Oracle R2DBC Driver with an 18 XE Oracle Database
+  test-18-xe:
     needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Test with Oracle Database
-        run: cd $GITHUB_WORKSPACE/.github/workflows && bash test.sh
+      - name: Test with Oracle Database 18 XE
+        run: cd $GITHUB_WORKSPACE/.github/workflows && bash test.sh 18.4.0
+  # Tests the Oracle R2DBC Driver with a 21.3 XE Oracle Database
+  test-21.3-xe:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Test with Oracle Database 21.3 XE
+        run: cd $GITHUB_WORKSPACE/.github/workflows && bash test.sh 21.3.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,8 +51,8 @@ jobs:
         java-version: 11
     - name: Build with Maven
       run: mvn -B package --file pom.xml -DskipTests=true
-  # Tests the Oracle R2DBC Driver with an 18 XE Oracle Database
-  test-18-xe:
+  # Tests the Oracle R2DBC Driver with an 18.4 XE Oracle Database
+  test-18.4-xe:
     needs: build
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -45,13 +45,12 @@ echo "touch $startUpMount/done" > $startUpScripts/99_done.sh
 
 # The oracle/docker-images repo is cloned. This repo provides Dockerfiles along
 # with a handy script to build images of Oracle Database. For now, this script
-# is just going to build an 18.4.0 XE image, because this can be done in an
-# automated fashion, without having to accept license agreements required by
-# newer versions like 19 and 21.
-# TODO: Also test with newer database versions
+# is just going to build an Express Edition (XE) image, because this can be 
+# done in an automated fashion. Other editions would require a script to accept
+# a license agreement.
 git clone https://github.com/oracle/docker-images.git
 cd docker-images/OracleDatabase/SingleInstance/dockerfiles/
-./buildContainerImage.sh -v 18.4.0 -x
+./buildContainerImage.sh -v $1 -x
 
 # Run the image in a detached container
 # The startup directory is mounted. It contains a createUser.sql script that
@@ -59,7 +58,7 @@ cd docker-images/OracleDatabase/SingleInstance/dockerfiles/
 # database has started.
 # The database port number, 1521, is mapped to the host system. The Oracle
 # R2DBC test suite is configured to connect with this port.
-docker run --name test_db --detach --rm -p 1521:1521 -v $startUpScripts:$startUpMount oracle/database:18.4.0-xe
+docker run --name test_db --detach --rm -p 1521:1521 -v $startUpScripts:$startUpMount oracle/database:$1-xe
 
 # Wait for the database instance to start. The final startup script will create
 # a file named "done" in the startup directory. When that file exists, it means
@@ -72,9 +71,9 @@ do
 done
 
 # Create a configuration file and run the tests. The service name, "xepdb1",
-# is always created for the 18.4.0 XE database, but it would probably change
-# for other database versions (TODO). The test user is created by the
-# startup/01_createUser.sql script
+# is always created for the XE database. It would probably change for other 
+# database editions. The test user is created by the startup/01_createUser.sql
+# script
 cd $GITHUB_WORKSPACE
 echo "DATABASE=xepdb1" > src/test/resources/config.properties
 echo "HOST=localhost" >> src/test/resources/config.properties


### PR DESCRIPTION
This is a work in progress. I'm creating the pull request in order to verify if the new test action is working correctly.

This branch adds a new action to the github workflow. It will create and run a docker image of Oracle Database 21.3 XE, and then verify Oracle R2DBC with this database.

This action will execute along side the existing test action for the 18.4 XE database.