### PR TITLE
66 vsession options

### DIFF
--- a/.github/workflows/startup/01_createUser.sql
+++ b/.github/workflows/startup/01_createUser.sql
@@ -34,10 +34,12 @@
 -- tables, and to query some V$ views:
 --   v$open_cursor (to verify if cursors are being closed).
 --   v$transaction (to verify if TransactionDefinitions are applied).
+--   v$session (to verify if VSESSION_* Options are applied).
 ALTER SESSION SET CONTAINER=xepdb1;
 CREATE ROLE r2dbc_test_user;
 GRANT SELECT ON v_$open_cursor TO r2dbc_test_user;
 GRANT SELECT ON v_$transaction TO r2dbc_test_user;
+GRANT SELECT ON v_$session TO r2dbc_test_user;
 
 CREATE USER test IDENTIFIED BY test;
 GRANT connect, resource, unlimited tablespace, r2dbc_test_user TO test;

--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -223,4 +223,40 @@ public final class OracleR2dbcOptions {
    */
   public static final Option<CharSequence> ENABLE_QUERY_RESULT_CACHE =
     Option.valueOf(OracleConnection.CONNECTION_PROPERTY_ENABLE_QUERY_RESULT_CACHE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_TERMINAL}
+   */
+  public static final Option<CharSequence> VSESSION_TERMINAL =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_VSESSION_TERMINAL);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_MACHINE}
+   */
+  public static final Option<CharSequence> VSESSION_MACHINE =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_VSESSION_MACHINE);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_OSUSER}
+   */
+  public static final Option<CharSequence> VSESSION_OSUSER =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_VSESSION_OSUSER);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_PROGRAM}
+   */
+  public static final Option<CharSequence> VSESSION_PROGRAM =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_VSESSION_PROGRAM);
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_PROCESS}
+   */
+  public static final Option<CharSequence> VSESSION_PROCESS =
+    Option.valueOf(OracleConnection.CONNECTION_PROPERTY_THIN_VSESSION_PROCESS);
+
 }

--- a/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
@@ -126,17 +126,20 @@ import static org.reactivestreams.FlowAdapters.toPublisher;
 final class OracleReactiveJdbcAdapter implements ReactiveJdbcAdapter {
 
   /**
+   * <p>
    * The set of JDBC connection properties that this adapter supports. Each
    * property in this set is represented as an {@link Option} having the name
    * of the supported JDBC connection property. When a property is configured
    * with a sensitive value, such as a password, it is represented in this
    * set as a {@linkplain Option#sensitiveValueOf(String) sensitive Option}.
+   * </p><p>
    * If a new Option is added to this set, then it <i>must</i> be documented
    * in the javadoc of {@link #createDataSource(ConnectionFactoryOptions)},
    * and in any other reference that lists which options the Oracle R2DBC Driver
    * supports. Undocumented options are useless; Other programmers won't be
    * able to use an option if they have no way to understand what the option
    * does or how it should be configured.
+   * </p>
    */
   private static final Set<Option<CharSequence>>
     JDBC_CONNECTION_PROPERTY_OPTIONS = Set.of(
@@ -198,7 +201,14 @@ final class OracleReactiveJdbcAdapter implements ReactiveJdbcAdapter {
       // Allow the client-side ResultSet cache to be disabled. It is
       // necessary to do so when using the serializable transaction isolation
       // level in order to prevent phantom reads.
-      OracleR2dbcOptions.ENABLE_QUERY_RESULT_CACHE
+      OracleR2dbcOptions.ENABLE_QUERY_RESULT_CACHE,
+
+      // Allow v$session attributes to be configured for tracing
+      OracleR2dbcOptions.VSESSION_OSUSER,
+      OracleR2dbcOptions.VSESSION_TERMINAL,
+      OracleR2dbcOptions.VSESSION_PROCESS,
+      OracleR2dbcOptions.VSESSION_PROGRAM,
+      OracleR2dbcOptions.VSESSION_MACHINE
     );
 
   /** Guards access to a JDBC {@code Connection} created by this adapter */
@@ -379,6 +389,21 @@ final class OracleReactiveJdbcAdapter implements ReactiveJdbcAdapter {
    *   </li><li>
    *   {@linkplain OracleConnection#CONNECTION_PROPERTY_IMPLICIT_STATEMENT_CACHE_SIZE
    *     oracle.jdbc.implicitStatementCacheSize}
+   *   </li><li>
+   *   {@linkplain OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_OSUSER
+   *     v$session.osuser}
+   *   </li><li>
+   *   {@linkplain OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_TERMINAL
+   *     v$session.terminal}
+   *   </li><li>
+   *   {@linkplain OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_PROCESS
+   *     v$session.process}
+   *   </li><li>
+   *   {@linkplain OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_PROGRAM
+   *     v$session.program}
+   *   </li><li>
+   *   {@linkplain OracleConnection#CONNECTION_PROPERTY_THIN_VSESSION_MACHINE
+   *     v$session.machine}
    *   </li>
    * </ul>
    *


### PR DESCRIPTION
This branch adds support for configuring V$SESSION attributes, fixing issue #66.

Changes in this branch declare new instances of Option in OracleR2dbcOptions. These new Options can be configured programmatically, or as URL query parameters. 

The Options are translated into connection properties that configure the underlying Oracle JDBC connection.

Thanks again to @joao-rebelo for bringing this issue to our attention.