### PR TITLE
1.0.0 SPI Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
   <version>0.4.0</version>
   <name>oracle-r2dbc</name>
   <description>
-    Oracle R2DBC Driver implementing version 0.9.0 of the R2DBC SPI for Oracle Database.
+    Oracle R2DBC Driver implementing version 1.0.0 of the R2DBC SPI for Oracle Database.
   </description>
   <url>
     https://github.com/oracle/oracle-r2dbc
@@ -65,8 +65,8 @@
 
   <properties>
     <java.version>11</java.version>
-    <ojdbc.version>21.3.0.0</ojdbc.version>
-    <r2dbc.version>0.9.0.RELEASE</r2dbc.version>
+    <ojdbc.version>21.5.0.0</ojdbc.version>
+    <r2dbc.version>1.0.0.RELEASE</r2dbc.version>
     <reactor.version>3.3.0.RELEASE</reactor.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <junit.version>5.7.0</junit.version>

--- a/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
@@ -196,9 +196,8 @@ abstract class OracleResultImpl implements Result {
    * </p>
    */
   @Override
-  public Publisher<Integer> getRowsUpdated() {
-    return publishSegments(UpdateCount.class,
-      updateCount -> Math.toIntExact(updateCount.value()));
+  public Publisher<Long> getRowsUpdated() {
+    return publishSegments(UpdateCount.class, UpdateCount::value);
   }
 
   /**

--- a/src/main/java/oracle/r2dbc/impl/ReadablesMetadata.java
+++ b/src/main/java/oracle/r2dbc/impl/ReadablesMetadata.java
@@ -237,22 +237,6 @@ class ReadablesMetadata<T extends ReadableMetadata> {
     public boolean contains(String columnName) {
       return getColumnIndex(columnName) != -1;
     }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Implements the R2DBC SPI method by returning a view of the column metadata
-     * objects, with each list entry mapped to {@link ColumnMetadata#getName()}.
-     * As specified by the SPI method documentation, the returned collection is
-     * unmodifiable, imposes the same column ordering as the query result, and
-     * supports case insensitive look ups.
-     * </p>
-     */
-    @Override
-    public Collection<String> getColumnNames() {
-      throw new UnsupportedOperationException(
-        "This method is deprecated for removal");
-    }
   }
 
   static final class OutParametersMetadataImpl

--- a/src/test/java/oracle/r2dbc/impl/OracleConnectionImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleConnectionImplTest.java
@@ -952,7 +952,7 @@ public class OracleConnectionImplTest {
             "Unexpected value returned by isAutoCommit() before subscribing to"
               + " setAutoCommit(true) publisher");
           awaitMany(
-            List.of(1, 1),
+            List.of(1L, 1L),
             Flux.from(sessionA.createBatch()
               .add("INSERT INTO testSetAutoCommit VALUES ('C')")
               .add("INSERT INTO testSetAutoCommit VALUES ('C')")

--- a/src/test/java/oracle/r2dbc/impl/OracleResultImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleResultImplTest.java
@@ -89,9 +89,9 @@ public class OracleResultImplTest {
           .toIterable()
           .iterator();
       Result insertResult0 = insertResults.next();
-      Publisher<Integer> insertCountPublisher0 =
+      Publisher<Long> insertCountPublisher0 =
         insertResult0.getRowsUpdated();
-      awaitOne(1, insertCountPublisher0);
+      awaitOne(1L, insertCountPublisher0);
 
       // Expect IllegalStateException from multiple Result consumptions.
       assertThrows(IllegalStateException.class,
@@ -100,12 +100,12 @@ public class OracleResultImplTest {
         () -> insertResult0.map((row, metadata) -> "unexpected"));
 
       // Expect update count publisher to support multiple subscribers
-      awaitOne(1, insertCountPublisher0);
+      awaitOne(1L, insertCountPublisher0);
 
       Result insertResult1 = insertResults.next();
-      Publisher<Integer> insertCountPublisher1 =
+      Publisher<Long> insertCountPublisher1 =
         insertResult1.getRowsUpdated();
-      awaitOne(1, insertCountPublisher1);
+      awaitOne(1L, insertCountPublisher1);
 
       // Expect IllegalStateException from multiple Result consumptions.
       assertThrows(IllegalStateException.class,
@@ -114,16 +114,16 @@ public class OracleResultImplTest {
         () -> insertResult1.map((row, metadata) -> "unexpected"));
 
       // Expect update count publisher to support multiple subscribers
-      awaitOne(1, insertCountPublisher1);
+      awaitOne(1L, insertCountPublisher1);
 
       // Expect an update count of zero from UPDATE of zero rows
       consumeOne(connection.createStatement(
         "UPDATE testGetRowsUpdated SET y = 99 WHERE x = 99")
         .execute(),
         noUpdateResult -> {
-          Publisher<Integer> noUpdateCountPublisher =
+          Publisher<Long> noUpdateCountPublisher =
             noUpdateResult.getRowsUpdated();
-          awaitOne(0, noUpdateCountPublisher);
+          awaitOne(0L, noUpdateCountPublisher);
 
           // Expect IllegalStateException from multiple Result consumptions.
           assertThrows(IllegalStateException.class,
@@ -131,7 +131,7 @@ public class OracleResultImplTest {
           assertThrows(IllegalStateException.class, noUpdateResult::getRowsUpdated);
 
           // Expect update count publisher to support multiple subscribers
-          awaitOne(0, noUpdateCountPublisher);
+          awaitOne(0L, noUpdateCountPublisher);
         });
 
       // Expect update count of 2 from UPDATE of 2 rows
@@ -139,8 +139,8 @@ public class OracleResultImplTest {
         "UPDATE testGetRowsUpdated SET y = 2 WHERE x = 0")
         .execute(),
         updateResult -> {
-        Publisher<Integer> updateCountPublisher = updateResult.getRowsUpdated();
-        awaitOne(2, updateCountPublisher);
+        Publisher<Long> updateCountPublisher = updateResult.getRowsUpdated();
+        awaitOne(2L, updateCountPublisher);
 
         // Expect IllegalStateException from multiple Result consumptions.
         assertThrows(IllegalStateException.class,
@@ -148,7 +148,7 @@ public class OracleResultImplTest {
         assertThrows(IllegalStateException.class, updateResult::getRowsUpdated);
 
         // Expect update count publisher to support multiple subscribers
-        awaitOne(2, updateCountPublisher);
+        awaitOne(2L, updateCountPublisher);
       });
 
       // Expect no update count from SELECT
@@ -156,11 +156,11 @@ public class OracleResultImplTest {
         "SELECT x,y FROM testGetRowsUpdated")
         .execute())
         .flatMapMany(selectResult -> {
-          Publisher<Integer> selectCountPublisher =
+          Publisher<Long> selectCountPublisher =
             selectResult.getRowsUpdated();
 
           // Expect update count publisher to support multiple subscribers
-          Publisher<Integer> result = Flux.concat(
+          Publisher<Long> result = Flux.concat(
             Mono.from(selectCountPublisher).cache(),
             Mono.from(selectCountPublisher).cache());
 
@@ -178,8 +178,8 @@ public class OracleResultImplTest {
         .bind("x", 0)
         .execute(),
         deleteResult -> {
-          Publisher<Integer> deleteCountPublisher = deleteResult.getRowsUpdated();
-          awaitOne(2, deleteCountPublisher);
+          Publisher<Long> deleteCountPublisher = deleteResult.getRowsUpdated();
+          awaitOne(2L, deleteCountPublisher);
 
           // Expect IllegalStateException from multiple Result consumptions.
           assertThrows(IllegalStateException.class,
@@ -187,7 +187,7 @@ public class OracleResultImplTest {
           assertThrows(IllegalStateException.class, deleteResult::getRowsUpdated);
 
           // Expect update count publisher to support multiple subscribers
-          awaitOne(2, deleteCountPublisher);
+          awaitOne(2L, deleteCountPublisher);
         });
     }
     finally {
@@ -473,7 +473,7 @@ public class OracleResultImplTest {
       // UpdateCount segment to be published by getRowsUpdated
       AtomicReference<UpdateCount> unfilteredUpdateCount =
         new AtomicReference<>(null);
-      awaitOne(1, Flux.from(connection.createStatement(
+      awaitOne(1L, Flux.from(connection.createStatement(
         "INSERT INTO testFilter VALUES (1)")
         .execute())
         .map(result ->
@@ -529,7 +529,7 @@ public class OracleResultImplTest {
         .execute())
         .block(sqlTimeout());
       Result filteredResult = unfilteredResult.filter(segment -> false);
-      Publisher<Integer> filteredUpdateCounts = filteredResult.getRowsUpdated();
+      Publisher<Long> filteredUpdateCounts = filteredResult.getRowsUpdated();
       assertThrows(
         IllegalStateException.class, unfilteredResult::getRowsUpdated);
       assertThrows(
@@ -545,13 +545,13 @@ public class OracleResultImplTest {
         .block(sqlTimeout());
       Result filteredResult2 = unfilteredResult2.filter(segment ->
         fail("Unexpected invocation"));
-      Publisher<Integer> unfilteredUpdateCounts =
+      Publisher<Long> unfilteredUpdateCounts =
         unfilteredResult2.getRowsUpdated();
       assertThrows(
         IllegalStateException.class, filteredResult2::getRowsUpdated);
       assertThrows(
         IllegalStateException.class, unfilteredResult2::getRowsUpdated);
-      awaitOne(1, unfilteredUpdateCounts);
+      awaitOne(1L, unfilteredUpdateCounts);
 
       // Execute an INSERT that fails, and filter Message type segments.
       // Expect the Result to not emit {@code onError} when consumed.

--- a/src/test/java/oracle/r2dbc/test/OracleTestKit.java
+++ b/src/test/java/oracle/r2dbc/test/OracleTestKit.java
@@ -213,9 +213,9 @@ public class OracleTestKit implements TestKit<Integer> {
    * </p>
    */
   @Override
-  public Mono<Integer> extractRowsUpdated(Result result) {
+  public Mono<Long> extractRowsUpdated(Result result) {
     return Flux.from(result.getRowsUpdated())
-      .reduce(0, (total, updateCount) -> total + updateCount);
+      .reduce(0L, (total, updateCount) -> total + updateCount);
   }
 
   @Override

--- a/src/test/java/oracle/r2dbc/util/Awaits.java
+++ b/src/test/java/oracle/r2dbc/util/Awaits.java
@@ -269,6 +269,7 @@ public final class Awaits {
       expectedCounts,
       Flux.from(statement.execute())
         .flatMap(result -> Flux.from(result.getRowsUpdated()))
+        .map(Math::toIntExact)
         .collectList()
         .block(sqlTimeout()),
       "Unexpected update counts");


### PR DESCRIPTION
This branch updates the SPI version implemented by Oracle R2DBC. The driver now implements version 1.0.0 of the SPI.

The getColumnNames method is removed from implementations of RowMetadata and OutParametersMetadata. This method was removed in SPI version 1.0.0.

The getUpdateCount method of the Result implementation is modified to return a Publisher<Long>. Previous SPI versions had this method return Publisher<Integer>, but in version 1.0.0 it now returns Publisher<Long>

The Oracle JDBC dependency is also updated to version 21.5, which is the latest version available currently. This is done to ensure Oracle R2DBC is benefiting from the latest fixes and improvements in Oracle JDBC.