### PR TITLE
Oracle Warning Segments

### DIFF
--- a/.github/workflows/startup/01_createUser.sql
+++ b/.github/workflows/startup/01_createUser.sql
@@ -36,12 +36,13 @@
 --   v$transaction (to verify if TransactionDefinitions are applied).
 --   v$session (to verify if VSESSION_* Options are applied).
 ALTER SESSION SET CONTAINER=xepdb1;
-CREATE ROLE r2dbc_test_user;
-GRANT SELECT ON v_$open_cursor TO r2dbc_test_user;
-GRANT SELECT ON v_$transaction TO r2dbc_test_user;
-GRANT SELECT ON v_$session TO r2dbc_test_user;
+CREATE ROLE r2dbc_test_role;
+GRANT SELECT ON v_$open_cursor TO r2dbc_test_role;
+GRANT SELECT ON v_$transaction TO r2dbc_test_role;
+GRANT SELECT ON v_$session TO r2dbc_test_role;
+GRANT CREATE VIEW TO r2dbc_test_role;
 
 CREATE USER test IDENTIFIED BY test;
-GRANT connect, resource, unlimited tablespace, r2dbc_test_user TO test;
+GRANT connect, resource, unlimited tablespace, r2dbc_test_role TO test;
 ALTER USER test DEFAULT TABLESPACE users;
 ALTER USER test TEMPORARY TABLESPACE temp;

--- a/src/main/java/oracle/r2dbc/OracleR2dbcWarning.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcWarning.java
@@ -1,6 +1,5 @@
 package oracle.r2dbc;
 
-import io.r2dbc.spi.R2dbcException;
 import io.r2dbc.spi.Result;
 
 import java.util.function.Function;
@@ -8,8 +7,8 @@ import java.util.function.Predicate;
 
 /**
  * <p>
- * A subtype of the {@link Result.Segment} interface that provides information
- * on warnings raised by Oracle Database.
+ * A subtype of {@link Result.Message} that provides information on warnings
+ * raised by Oracle Database.
  * </p><p>
  * When a SQL command results in a warning, Oracle R2DBC emits a {@link Result}
  * with an {@code OracleR2dbcWarning} segment in addition to any other segments

--- a/src/main/java/oracle/r2dbc/OracleR2dbcWarning.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcWarning.java
@@ -53,29 +53,6 @@ import java.util.function.Predicate;
  * }</pre>
  * @since 1.1.0
  */
-public interface OracleR2dbcWarning extends Result.Segment {
+public interface OracleR2dbcWarning extends Result.Message {
 
-  /**
-   * Returns the warning as an {@link R2dbcException}.
-   * @return The warning as an {@link R2dbcException}. Not null.
-   */
-  R2dbcException exception();
-
-  /**
-   * Returns the error code of the warning.
-   * @return The error code of the warning.
-   */
-  int errorCode();
-
-  /**
-   * Returns the SQLState of the warning.
-   * @return The SQLState of the warning. Not null.
-   */
-  String sqlState();
-
-  /**
-   * Returns the text of the warning message.
-   * @return The text of the warning message. Not null.
-   */
-  String message();
 }

--- a/src/main/java/oracle/r2dbc/OracleR2dbcWarning.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcWarning.java
@@ -1,0 +1,87 @@
+package oracle.r2dbc;
+
+import io.r2dbc.spi.R2dbcException;
+import io.r2dbc.spi.Result;
+
+import java.sql.SQLWarning;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import static io.r2dbc.spi.Result.*;
+
+/**
+ * <p>
+ * An exception that provides information on warnings raised by Oracle Database.
+ * </p><p>
+ * When a SQL command results in a warning, Oracle R2DBC generates
+ * {@link Message} segments having an {@code OracleR2dbcWarning} as the
+ * {@linkplain Message#exception() exception}. These segments may be consumed
+ * with {@link Result#flatMap(Function)}:
+ * </p><pre>{@code
+ * result.flatMap(segment -> {
+ *   if (OracleR2dbcWarning.isWarning(segment)) {
+ *     logWarning(OracleR2dbcWarning.getWarning(segment));
+ *     return emptyPublisher();
+ *   }
+ *   else {
+ *     ... handle other segment types ...
+ *   }
+ * })
+ * }</pre><p>
+ * Alternatively, these segments may be ignored using
+ * {@link Result#filter(Predicate)}:
+ * </p> <pre>{@code
+ * result.filter(segment -> !OracleR2dbcWarning.isWarning(segment))
+ * }</pre>
+ * If these segments are not flat-mapped or filtered from a {@code Result}, then
+ * an {@code onError} signal with the {@code OracleR2dbcWarning} is emitted 
+ * </p>
+ */
+public class OracleR2dbcWarning extends R2dbcException {
+
+  /**
+   * Constructs a new warning having a {@code SQLWarning} from JDBC as its
+   * cause. The constructed warning has the same message, SQL state, and error
+   * code as the given {@code SQLWarning}.
+   * @param sql The SQL command that resulted in a warning. May be null.
+   * @param sqlWarning The SQLWarning thrown by JDBC. Not null.
+   */
+  public OracleR2dbcWarning(String sql, SQLWarning sqlWarning) {
+    super(sqlWarning.getMessage(), sqlWarning.getSQLState(),
+      sqlWarning.getErrorCode(), sql, sqlWarning);
+  }
+
+  /**
+   * Checks if a segment is a {@link Message} having an
+   * {@code OracleR2dbcException} as an
+   * {@linkplain Message#exception() exception}.
+   * @param segment Segment to check. May be null, in which case {@code false}
+   * is returned.
+   * @return {@code true} if the segment is a {@code Message} with an
+   * {@code OracleR2dbcException}, or {@code false} if not.
+   */
+  public static boolean isWarning(Segment segment) {
+    return segment instanceof Message
+      && ((Message)segment).exception() instanceof OracleR2dbcWarning;
+  }
+
+  /**
+   * Returns the {@code OracleR2dbcWarning} of a {@link Message} segment. This
+   * method should only be called if {@link #isWarning(Segment)} returned
+   * {@code true} for the given segment.
+   * @param segment A {@code Message} segment with an
+   * {@code OracleR2dbcWarning}. Not null.
+   * @return The {@code OracleR2dbcWarning} of the {@code Message} segment.
+   * @throws IllegalArgumentException If the segment is not a {@code Message}
+   * with an {@code OracleR2dbcWarning}.
+   */
+  public static OracleR2dbcWarning getWarning(Segment segment) {
+    if (!isWarning(segment)) {
+      throw new IllegalArgumentException(
+        "Not a Message segment with an OracleR2dbcWarning: " + segment);
+    }
+
+    return (OracleR2dbcWarning)((Message)segment).exception();
+  }
+
+}

--- a/src/main/java/oracle/r2dbc/impl/OracleR2dbcExceptions.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleR2dbcExceptions.java
@@ -31,6 +31,7 @@ import io.r2dbc.spi.R2dbcTimeoutException;
 import io.r2dbc.spi.R2dbcTransientException;
 import io.r2dbc.spi.R2dbcTransientResourceException;
 import oracle.jdbc.OracleDatabaseException;
+import oracle.r2dbc.OracleR2dbcWarning;
 
 import java.sql.SQLException;
 import java.sql.SQLIntegrityConstraintViolationException;
@@ -42,6 +43,7 @@ import java.sql.SQLTimeoutException;
 import java.sql.SQLTransactionRollbackException;
 import java.sql.SQLTransientConnectionException;
 import java.sql.SQLTransientException;
+import java.sql.SQLWarning;
 import java.util.function.Supplier;
 
 /**
@@ -213,6 +215,9 @@ final class OracleR2dbcExceptions {
       // expresses the same conditions.
       return new R2dbcTransientResourceException(
         message, sqlState, errorCode, sql, sqlException);
+    }
+    else if (sqlException instanceof SQLWarning) {
+      return new OracleR2dbcWarning(sql, (SQLWarning)sqlException);
     }
     else {
       return new OracleR2dbcException(

--- a/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
@@ -151,6 +151,8 @@ abstract class OracleResultImpl implements Result {
       Flux.from(publishSegments(segment -> {
         if (type.isInstance(segment))
           return mappingFunction.apply(type.cast(segment));
+        else if (segment instanceof OracleR2dbcWarning)
+          return (U)FILTERED;
         else if (segment instanceof Message)
           throw ((Message)segment).exception();
         else
@@ -784,7 +786,7 @@ abstract class OracleResultImpl implements Result {
   /**
    * Implementation of {@link Message}.
    */
-  private static final class MessageImpl implements Message {
+  private static class MessageImpl implements Message {
 
     private final R2dbcException exception;
 
@@ -811,38 +813,24 @@ abstract class OracleResultImpl implements Result {
     public String message() {
       return exception.getMessage();
     }
+
+    @Override
+    public String toString() {
+      return exception.toString();
+    }
   }
 
   /**
    * Implementation of {@link OracleR2dbcWarning}.
    */
-  private static final class WarningImpl implements OracleR2dbcWarning {
-
-    private final R2dbcException warning;
+  private static final class WarningImpl
+    extends MessageImpl
+    implements OracleR2dbcWarning {
 
     private WarningImpl(R2dbcException exception) {
-      this.warning = exception;
+      super(exception);
     }
 
-    @Override
-    public R2dbcException exception() {
-      return warning;
-    }
-
-    @Override
-    public int errorCode() {
-      return warning.getErrorCode();
-    }
-
-    @Override
-    public String sqlState() {
-      return warning.getSqlState();
-    }
-
-    @Override
-    public String message() {
-      return warning.getMessage();
-    }
   }
 
   /**

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -1132,7 +1132,7 @@ final class OracleStatementImpl implements Statement {
         preparedStatement.clearWarnings();
         return warning == null
           ? result
-          : OracleResultImpl.createWarningResult(warning, result);
+          : OracleResultImpl.createWarningResult(sql, warning, result);
       });
     }
 

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -35,6 +35,7 @@ import io.r2dbc.spi.Result.UpdateCount;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.Type;
 import oracle.r2dbc.OracleR2dbcOptions;
+import oracle.r2dbc.OracleR2dbcWarning;
 import oracle.r2dbc.test.DatabaseConfig;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -1997,7 +1998,7 @@ public class OracleStatementImplTest {
 
   /**
    * Verifies that {@link OracleStatementImpl#execute()} emits a {@link Result}
-   * with a {@link Message} segment when the execution results in a
+   * with a {@link OracleR2dbcWarning} segment when the execution results in a
    * warning.
    */
   @Test
@@ -2007,9 +2008,10 @@ public class OracleStatementImplTest {
     try {
 
       // Create a procedure using invalid syntax and expect the Result to
-      // have a Message with an R2dbcException having a SQLWarning as it's
-      // initial cause. Expect the Result to have an update count of zero as
-      // well, indicating that the statement completed after the warning.
+      // have an OracleR2dbcWarning with an R2dbcException having a SQLWarning
+      // as it's initial cause. Expect the Result to have an update count of
+      // zero as well, indicating that the statement completed after the
+      // warning.
       AtomicInteger segmentCount = new AtomicInteger(0);
       R2dbcException r2dbcException =
         awaitOne(Flux.from(connection.createStatement(
@@ -2020,9 +2022,9 @@ public class OracleStatementImplTest {
             result.flatMap(segment -> {
               int index = segmentCount.getAndIncrement();
               if (index == 0) {
-                assertTrue(segment instanceof Message,
+                assertTrue(segment instanceof OracleR2dbcWarning,
                   "Unexpected Segment: " + segment);
-                return Mono.just(((Message)segment).exception());
+                return Mono.just(((OracleR2dbcWarning)segment).exception());
               }
               else if (index == 1) {
                 assertTrue(segment instanceof UpdateCount,


### PR DESCRIPTION
This branch adds a new Result.Segment type for database warnings. The new type is intended for consumption by user code, so it is added as a public type in the oracle.r2dbc package: OracleR2dbcWarning.

In the previous release, warnings were emitted as Result.Message segments. Message segments cause onError signals to be emitted when consuming results of SQL calls.  Based on discussions with several users, I'm convinced that this behavior was not correct. 
In the case of a warning, an onError signal is not helpful as it prevents user code from consuming the actual result of the SQL call. For instance, a call to Result.map(Function) would result in an error even if rows were successfully queried, but a warning was raised.

With this branch, warnings are emitted as a distinct message type. User code may choose to consume the warning if desired, but otherwise the warning will be ignored. This model is inspired by the JDBC API, which does not throw SQLWarning exceptions, but instead requires an explicit call to a getWarnings method.

Although it is similar to Result.Message, I choose to make OracleR2dbcWarning a distinct type. The intent of this is to avoid confusion for driver agnostic code which may (rightfully so) consider all Message segments to be errors. Driver agnostic code can then remain agnostic, and not need to reference a type that is specific to Oracle R2DBC in order to discern between errors and warnings.

Thanks to @larousso and @rathoreamrsingh for providing helpful discussions that lead to this change. 