### PR TITLE
Array Types

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -81,6 +81,6 @@ echo "HOST=localhost" >> src/test/resources/config.properties
 echo "PORT=1521" >> src/test/resources/config.properties
 echo "USER=test" >> src/test/resources/config.properties
 echo "PASSWORD=test" >> src/test/resources/config.properties
-echo "CONNECT_TIMEOUT=120" >> src/test/resources/config.properties
-echo "SQL_TIMEOUT=120" >> src/test/resources/config.properties
+echo "CONNECT_TIMEOUT=180" >> src/test/resources/config.properties
+echo "SQL_TIMEOUT=180" >> src/test/resources/config.properties
 mvn clean compile test

--- a/README.md
+++ b/README.md
@@ -553,6 +553,29 @@ prefetched entirely, a smaller prefetch size can be configured using the
 option, and the LOB can be consumed as a stream. By mapping LOB columns to 
 `Blob` or `Clob` objects, the content can be consumed as a reactive stream. 
 
+### ARRAY
+Oracle Database supports `ARRAY` as a user defined type only. A `CREATE TYPE` 
+command is used to define an `ARRAY` type:
+```sql
+CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+```
+Oracle R2DBC defines `oracle.r2dbc.OracleR2dbcType.ArrayType` as a `Type` for
+representing user defined `ARRAY` types. A `Parameter` with an type of
+`ArrayType` must be used when binding array values to a `Statement` 
+```java
+Publisher<Result> arrayBindExample(Connection connection) {
+  Statement statement =
+    connection.createStatement("INSERT INTO example VALUES (:array_bind)");
+
+  // Use the name defined for an ARRAY type:
+  // CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+  ArrayType arrayType = OracleR2dbcTypes.arrayType("MY_ARRAY");
+  Integer[] arrayValues = {1, 2, 3};
+  statement.bind("arrayBind", Parameters.in(arrayType, arrayValues));
+
+  return statement.execute();
+}
+```
 ## Secure Programming Guidelines
 The following security related guidelines should be adhered to when programming
 with the Oracle R2DBC Driver.

--- a/README.md
+++ b/README.md
@@ -560,8 +560,8 @@ command is used to define an `ARRAY` type:
 CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
 ```
 Oracle R2DBC defines `oracle.r2dbc.OracleR2dbcType.ArrayType` as a `Type` for
-representing user defined `ARRAY` types. A `Parameter` with an type of
-`ArrayType` must be used when binding array values to a `Statement` 
+representing user defined `ARRAY` types. A `Parameter` with a type of
+`ArrayType` must be used when binding array values to a `Statement`.
 ```java
 Publisher<Result> arrayBindExample(Connection connection) {
   Statement statement =
@@ -574,6 +574,30 @@ Publisher<Result> arrayBindExample(Connection connection) {
   statement.bind("arrayBind", Parameters.in(arrayType, arrayValues));
 
   return statement.execute();
+}
+```
+A `Parameter` with a type of `ArrayType` must also be used when binding OUT
+parameters of a PL/SQL call.
+```java
+Publisher<Result> arrayOutBindExample(Connection connection) {
+  Statement statement =
+    connection.createStatement("BEGIN; exampleCall(:array_bind); END;");
+
+  // Use the name defined for an ARRAY type:
+  // CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+  ArrayType arrayType = OracleR2dbcTypes.arrayType("MY_ARRAY");
+  statement.bind("arrayBind", Parameters.out(arrayType));
+
+  return statement.execute();
+}
+```
+`ARRAY` values may be consumed from a `Row` or `OutParameter` as a Java array.
+The element type of the Java array may be any Java type that is supported as
+a mapping for the SQL type of the `ARRAY`. For instance, if the `ARRAY` type is
+`NUMBER`, then a `Integer[]` mapping is supported:
+```java
+Publisher<Integer[]> arrayMapExample(Result result) {
+  return result.map(readable -> readable.get("arrayValue", Integer[].class));
 }
 ```
 ## Secure Programming Guidelines

--- a/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
@@ -106,8 +106,8 @@ public final class OracleR2dbcTypes {
    * {@code CREATE TYPE} command that created the type used an "enquoted" type
    * name.
    * </p><p>
-   * The {@code ArrayType} object returned by this method may be used to a
-   * {@link Parameter} that binds an array value to a {@link Statement}.
+   * The {@code ArrayType} object returned by this method may be used to create
+   * a {@link Parameter} that binds an array value to a {@link Statement}.
    * </p><pre>{@code
    * Publisher<Result> arrayBindExample(Connection connection) {
    *   Statement statement =

--- a/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
@@ -20,6 +20,9 @@
 */
 package oracle.r2dbc;
 
+import io.r2dbc.spi.Parameter;
+import io.r2dbc.spi.R2dbcType;
+import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.Type;
 import oracle.sql.json.OracleJsonObject;
 
@@ -28,6 +31,7 @@ import java.sql.RowId;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.util.Objects;
 
 /**
  * SQL types supported by Oracle Database that are not defined as standard types
@@ -93,9 +97,101 @@ public final class OracleR2dbcTypes {
     new TypeImpl(LocalDateTime.class, "TIMESTAMP WITH LOCAL TIME ZONE");
 
   /**
+   * <p>
+   * Creates an {@link ArrayType} representing a user defined {@code ARRAY}
+   * type. The {@code name} passed to this method must identify the name of a
+   * user defined {@code ARRAY} type.
+   * </p><p>
+   * Typically, the name passed to this method should be UPPER CASE, unless the
+   * {@code CREATE TYPE} command that created the type used an "enquoted" type
+   * name.
+   * </p><p>
+   * The {@code ArrayType} object returned by this method may be used to a
+   * {@link Parameter} that binds an array value to a {@link Statement}.
+   * </p><pre>{@code
+   * Publisher<Result> arrayBindExample(Connection connection) {
+   *   Statement statement =
+   *     connection.createStatement("INSERT INTO example VALUES (:array_bind)");
+   *
+   *   // Use the name defined for an ARRAY type:
+   *   // CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+   *   ArrayType arrayType = OracleR2dbcTypes.arrayType("MY_ARRAY");
+   *   Integer[] arrayValues = {1, 2, 3};
+   *   statement.bind("arrayBind", Parameters.in(arrayType, arrayValues));
+   *
+   *   return statement.execute();
+   * }
+   * }</pre>
+   * @param name Name of a user defined ARRAY type. Not null.
+   * @return A {@code Type} object representing the user defined ARRAY type. Not
+   * null.
+   */
+  public static ArrayType arrayType(String name) {
+    return new ArrayTypeImpl(Objects.requireNonNull(name, "name is null"));
+  }
+
+  /**
+   * Extension of the standard {@link Type} interface used to represent user
+   * defined ARRAY types. An instance of {@code ArrayType} must be used when
+   * binding an array value to a {@link Statement} created by the Oracle R2DBC
+   * Driver.
+   * </p><p>
+   * Oracle Database does not support an anonymous {@code ARRAY} type, which is
+   * what the standard {@link R2dbcType#COLLECTION} type represents. Oracle
+   * Database only supports {@code ARRAY} types which are declared as a user
+   * defined type, as in:
+   * <pre>{@code
+   * CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+   * }</pre>
+   * In order to bind an array, the name of a user defined ARRAY type must
+   * be known to Oracle R2DBC. Instances of {@code ArrayType} retain the name
+   * that is provided to the {@link #arrayType(String)} factory method.
+   */
+  public interface ArrayType extends Type {
+
+    /**
+     * {@inheritDoc}
+     * Returns {@code Object[].class}, which is the standard mapping for
+     * {@link R2dbcType#COLLECTION}. The true default type mapping is the array
+     * variant of the default mapping for the element type of the {@code ARRAY}.
+     * For instance, an {@code ARRAY} of {@code VARCHAR} maps to a
+     * {@code String[]} by default.
+     */
+    @Override
+    Class<?> getJavaType();
+
+    /**
+     * {@inheritDoc}
+     * Returns the name of this user defined {@code ARRAY} type. For instance,
+     * this method returns "MY_ARRAY" if the type is declared as:
+     * <pre>{@code
+     * CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+     * }</pre>
+     */
+    @Override
+    String getName();
+  }
+
+  /** Concrete implementation of the {@code ArrayType} interface */
+  private static final class ArrayTypeImpl
+    extends TypeImpl implements ArrayType {
+
+    /**
+     * Constructs an ARRAY type with the given {@code name}. The constructed
+     * {@code ArrayType} as a default Java type mapping of
+     * {@code Object[].class}. This is consistent with the standard
+     * {@link R2dbcType#COLLECTION} type.
+     * @param name User defined name of the type. Not null.
+     */
+    ArrayTypeImpl(String name) {
+      super(Object[].class, name);
+    }
+  }
+
+  /**
    * Implementation of the {@link Type} SPI.
    */
-  private static final class TypeImpl implements Type {
+  private static class TypeImpl implements Type {
 
     /**
      * The Java Language mapping of this SQL type.

--- a/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
@@ -263,6 +263,11 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
    */
   static OutParameterMetadata createParameterMetadata(
     String name, Type type) {
+
+    // Translate the Oracle specific ArrayType to the standard COLLECTION type
+    if (type instanceof OracleR2dbcTypes.ArrayType)
+      type = R2dbcType.COLLECTION;
+
     return new OracleOutParameterMetadataImpl(
       type, name, Nullability.NULLABLE, null, null);
   }

--- a/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
@@ -478,7 +478,9 @@ abstract class OracleResultImpl implements Result {
 
       // Avoiding object allocating by reusing the same Row object
       ReusableJdbcReadable reusableJdbcReadable = new ReusableJdbcReadable();
-      Row row = createRow(reusableJdbcReadable, metadata, adapter);
+      Row row = createRow(
+        fromJdbc(() -> resultSet.getStatement().getConnection()),
+        reusableJdbcReadable, metadata, adapter);
 
       return adapter.publishRows(resultSet, jdbcReadable -> {
         reusableJdbcReadable.current = jdbcReadable;

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -1374,11 +1374,14 @@ final class OracleStatementImpl implements Statement {
       OracleR2dbcTypes.ArrayType type, Object value) {
 
       final Object jdbcValue;
+      Class<?> componentType = value.getClass().getComponentType();
+      while (componentType.isArray())
+        componentType = componentType.getComponentType();
 
       if (value instanceof byte[]) {
         // Oracle JDBC does not support creating SQL arrays from a byte[], so
         // convert it to an short[].
-        byte[] bytes =  (byte[])value;
+        byte[] bytes = (byte[])value;
         short[] shorts = new short[bytes.length];
         for (int i = 0; i < bytes.length; i++)
           shorts[i] = (short)(0xFF & bytes[i]);
@@ -1596,7 +1599,9 @@ final class OracleStatementImpl implements Statement {
       return Flux.concat(
         super.executeJdbc(),
         Mono.just(createCallResult(
-          createOutParameters(new JdbcOutParameters(), metadata, adapter),
+          createOutParameters(
+            fromJdbc(preparedStatement::getConnection),
+            new JdbcOutParameters(), metadata, adapter),
           adapter)));
     }
 

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -1574,7 +1574,19 @@ final class OracleStatementImpl implements Statement {
         for (int i : outBindIndexes) {
           Type type = ((Parameter) binds[i]).getType();
           SQLType jdbcType = toJdbcType(type);
-          callableStatement.registerOutParameter(i + 1, jdbcType);
+
+          if (type instanceof OracleR2dbcTypes.ArrayType) {
+            // Call registerOutParameter with the user defined type name
+            // returned by ArrayType.getName(). Oracle JDBC throws an exception
+            // if a name is provided for a built-in type, like VARCHAR, etc. So
+            // this branch should only be taken for user defined types, like
+            // ARRAY.
+            callableStatement.registerOutParameter(
+              i + 1, jdbcType, type.getName());
+          }
+          else {
+            callableStatement.registerOutParameter(i + 1, jdbcType);
+          }
         }
       });
     }

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -976,7 +976,20 @@ final class OracleStatementImpl implements Statement {
 
     /**
      * <p>
-     * Sets {@link #binds} on the {@link #preparedStatement}. The
+     * Sets {@link #binds} on the {@link #preparedStatement}, as specified by
+     * {@link #bind(Object[])}. This method is called when this statement is
+     * executed. Subclasess override this method to perform additional actions.
+     * </p>
+     * @return A {@code Publisher} that emits {@code onComplete} when all
+     * {@code binds} have been set.
+     */
+    protected Publisher<Void> bind() {
+      return bind(binds);
+    }
+
+    /**
+     * <p>
+     * Sets the given {@code binds} on the {@link #preparedStatement}. The
      * returned {@code Publisher} completes after all bind values have
      * materialized and been set on the {@code preparedStatement}.
      * </p><p>
@@ -988,10 +1001,6 @@ final class OracleStatementImpl implements Statement {
      * @return A {@code Publisher} that emits {@code onComplete} when all
      * {@code binds} have been set.
      */
-    protected Publisher<Void> bind() {
-      return bind(binds);
-    }
-
     protected final Publisher<Void> bind(Object[] binds) {
       return adapter.getLock().flatMap(() -> {
 

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -30,11 +30,11 @@ import io.r2dbc.spi.R2dbcException;
 import io.r2dbc.spi.R2dbcNonTransientException;
 import io.r2dbc.spi.R2dbcType;
 import io.r2dbc.spi.Result;
-import io.r2dbc.spi.Result.Message;
 import io.r2dbc.spi.Result.UpdateCount;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.Type;
 import oracle.r2dbc.OracleR2dbcOptions;
+import oracle.r2dbc.OracleR2dbcTypes;
 import oracle.r2dbc.OracleR2dbcWarning;
 import oracle.r2dbc.test.DatabaseConfig;
 import org.junit.jupiter.api.Test;
@@ -45,9 +45,12 @@ import reactor.core.publisher.Signal;
 
 import java.sql.RowId;
 import java.sql.SQLWarning;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1279,7 +1282,7 @@ public class OracleStatementImplTest {
       // inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(?); END;")
-        .bind(0, new InOutParameter(1, R2dbcType.NUMERIC))
+        .bind(0, Parameters.inOut(R2dbcType.NUMERIC, 1))
         .execute(),
         result -> {
           awaitNone(result.getRowsUpdated());
@@ -1293,7 +1296,7 @@ public class OracleStatementImplTest {
       // parameter's default value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(:value); END;")
-        .bind("value", new InOutParameter(2, R2dbcType.NUMERIC))
+        .bind("value", Parameters.inOut(R2dbcType.NUMERIC, 2))
         .execute(),
         result ->
           awaitOne(1, result.map(row ->
@@ -1307,7 +1310,7 @@ public class OracleStatementImplTest {
       // parameter's value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(:value); END;")
-        .bind("value", new InOutParameter(3))
+        .bind("value", Parameters.inOut(3))
         .execute(),
         result ->
           awaitNone(result.getRowsUpdated()));
@@ -1320,7 +1323,7 @@ public class OracleStatementImplTest {
       // parameter's value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(?); END;")
-        .bind(0, new InOutParameter(4))
+        .bind(0, Parameters.inOut(4))
         .execute(),
         result ->
           awaitOne(3, result.map(row ->
@@ -1374,8 +1377,8 @@ public class OracleStatementImplTest {
       // inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(:value1, :value2); END;")
-        .bind("value1", new InOutParameter(1, R2dbcType.NUMERIC))
-        .bind("value2", new InOutParameter(101, R2dbcType.NUMERIC))
+        .bind("value1", Parameters.inOut(R2dbcType.NUMERIC, 1))
+        .bind("value2", Parameters.inOut(R2dbcType.NUMERIC, 101))
         .execute(),
         result ->
           awaitNone(result.getRowsUpdated()));
@@ -1389,8 +1392,8 @@ public class OracleStatementImplTest {
       // parameter's default value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(?, :value2); END;")
-        .bind(0, new InOutParameter(2, R2dbcType.NUMERIC))
-        .bind("value2", new InOutParameter(102, R2dbcType.NUMERIC))
+        .bind(0, Parameters.inOut(R2dbcType.NUMERIC, 2))
+        .bind("value2", Parameters.inOut(R2dbcType.NUMERIC, 102))
         .execute(),
         result ->
           awaitOne(asList(1, 101), result.map(row ->
@@ -1406,8 +1409,8 @@ public class OracleStatementImplTest {
       // parameter's value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(?, ?); END;")
-        .bind(0, new InOutParameter(3))
-        .bind(1, new InOutParameter(103))
+        .bind(0, Parameters.inOut(3))
+        .bind(1, Parameters.inOut(103))
         .execute(),
         result -> awaitNone(result.getRowsUpdated()));
       awaitQuery(asList(asList(3, 103)),
@@ -1422,8 +1425,8 @@ public class OracleStatementImplTest {
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(" +
           "inout_value2 => :value2, inout_value1 => :value1); END;")
-        .bind("value1", new InOutParameter(4))
-        .bind("value2", new InOutParameter(104))
+        .bind("value1", Parameters.inOut(4))
+        .bind("value2", Parameters.inOut(104))
         .execute(),
         result ->
           awaitOne(asList(3, 103), result.map(row ->
@@ -2238,39 +2241,307 @@ public class OracleStatementImplTest {
     }
   }
 
-  // TODO: Repalce with Parameters.inOut when that's available
-  private static final class InOutParameter
-    implements Parameter, Parameter.In, Parameter.Out {
-    final Type type;
-    final Object value;
+  /**
+   * Verifies behavior for a PL/SQL call having {@code ARRAY} type IN bind
+   */
+  @Test
+  public void testInArrayCall() {
+    Connection connection = awaitOne(sharedConnection());
+    try {
+      awaitExecution(connection.createStatement(
+        "CREATE TYPE TEST_IN_ARRAY AS ARRAY(8) OF NUMBER"));
+      awaitExecution(connection.createStatement(
+        "CREATE TABLE testInArrayCall(id NUMBER, value TEST_IN_ARRAY)"));
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE PROCEDURE testInArrayProcedure (" +
+          " id IN NUMBER," +
+          " inArray IN TEST_IN_ARRAY)" +
+          " IS" +
+          " BEGIN" +
+          " INSERT INTO testInArrayCall VALUES(id, inArray);" +
+          " END;"));
 
-    InOutParameter(Object value) {
-      this(value, new Type.InferredType() {
-        @Override
-        public Class<?> getJavaType() {
-          return value.getClass();
+      class TestRow {
+        Long id;
+        int[] value;
+        TestRow(Long id, int[] value) {
+          this.id = id;
+          this.value = value;
         }
 
         @Override
-        public String getName() {
-          return "Inferred";
+        public boolean equals(Object other) {
+          return other instanceof TestRow
+            && Objects.equals(((TestRow) other).id, id)
+            && Objects.deepEquals(((TestRow)other).value, value);
         }
-      });
-    }
 
-    InOutParameter(Object value, Type type) {
-      this.value = value;
-      this.type = type;
-    }
+        @Override
+        public String toString() {
+          return id + ", " + Arrays.toString(value);
+        }
+      }
 
-    @Override
-    public Type getType() {
-      return type;
-    }
+      TestRow row0 = new TestRow(0L, new int[]{1, 2, 3});
+      OracleR2dbcTypes.ArrayType arrayType =
+        OracleR2dbcTypes.arrayType("TEST_IN_ARRAY");
+      Statement callStatement = connection.createStatement(
+        "BEGIN testInArrayProcedure(:id, :value); END;");
+      awaitExecution(
+        callStatement
+          .bind("id", row0.id)
+          .bind("value", Parameters.in(arrayType, row0.value)));
 
-    @Override
-    public Object getValue() {
-      return value;
+      awaitQuery(
+        List.of(row0),
+        row ->
+          new TestRow(
+            row.get("id", Long.class),
+            row.get("value", int[].class)),
+        connection.createStatement(
+          "SELECT id, value FROM testInArrayCall ORDER BY id"));
+
+      TestRow row1 = new TestRow(1L, new int[]{4, 5, 6});
+      awaitExecution(
+        callStatement
+          .bind("id", row1.id)
+          .bind("value", Parameters.in(arrayType, row1.value)));
+
+      awaitQuery(
+        List.of(row0, row1),
+        row ->
+          new TestRow(
+            row.get("id", Long.class),
+            row.get("value", int[].class)),
+        connection.createStatement(
+          "SELECT id, value FROM testInArrayCall ORDER BY id"));
+    }
+    finally {
+      tryAwaitExecution(connection.createStatement(
+        "DROP TABLE testInArrayCall"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP PROCEDURE testInArrayProcedure"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_IN_ARRAY"));
+      tryAwaitNone(connection.close());
+    }
+  }
+
+  /**
+   * Verifies behavior for a PL/SQL call having {@code ARRAY} type OUT bind
+   */
+  @Test
+  public void testOutArrayCall() {
+    Connection connection = awaitOne(sharedConnection());
+    try {
+      awaitExecution(connection.createStatement(
+        "CREATE TYPE TEST_OUT_ARRAY AS ARRAY(8) OF NUMBER"));
+      awaitExecution(connection.createStatement(
+        "CREATE TABLE testOutArrayCall(id NUMBER, value TEST_OUT_ARRAY)"));
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE PROCEDURE testOutArrayProcedure (" +
+          "   inId IN NUMBER," +
+          "   outArray OUT TEST_OUT_ARRAY)" +
+          " IS" +
+          " BEGIN" +
+          "   SELECT value INTO outArray" +
+          "     FROM testOutArrayCall" +
+          "     WHERE id = inId;" +
+          " EXCEPTION" +
+          "   WHEN NO_DATA_FOUND THEN" +
+          "     outArray := NULL;" +
+          " END;"));
+
+      class TestRow {
+        Long id;
+        Integer[] value;
+        TestRow(Long id, Integer[] value) {
+          this.id = id;
+          this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+          return other instanceof TestRow
+            && Objects.equals(((TestRow) other).id, id)
+            && Objects.deepEquals(((TestRow)other).value, value);
+        }
+
+        @Override
+        public String toString() {
+          return id + ", " + Arrays.toString(value);
+        }
+      }
+
+      OracleR2dbcTypes.ArrayType arrayType =
+        OracleR2dbcTypes.arrayType("TEST_OUT_ARRAY");
+      Statement callStatement = connection.createStatement(
+        "BEGIN testOutArrayProcedure(:id, :value); END;");
+
+      // Expect a NULL out parameter before any rows have been inserted
+      awaitQuery(
+        List.of(Optional.empty()),
+        outParameters -> {
+          assertNull(outParameters.get("value"));
+          assertNull(outParameters.get("value", int[].class));
+          assertNull(outParameters.get("value", Integer[].class));
+          return Optional.empty();
+        },
+        callStatement
+          .bind("id", -1)
+          .bind("value", Parameters.out(arrayType)));
+
+      // Insert a row and expect an out parameter with the value
+      TestRow row0 = new TestRow(0L, new Integer[]{1, 2, 3});
+      awaitUpdate(1, connection.createStatement(
+          "INSERT INTO testOutArrayCall VALUES (:id, :value)")
+        .bind("id", row0.id)
+        .bind("value", Parameters.in(arrayType, row0.value)));
+      awaitQuery(
+        List.of(row0),
+        outParameters ->
+          new TestRow(row0.id, outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row0.id)
+          .bind("value", Parameters.out(arrayType)));
+
+      // Insert another row and expect an out parameter with the value
+      TestRow row1 = new TestRow(1L, new Integer[]{4, 5, 6});
+      awaitUpdate(1, connection.createStatement(
+          "INSERT INTO testOutArrayCall VALUES (:id, :value)")
+        .bind("id", row1.id)
+        .bind("value", Parameters.in(arrayType, row1.value)));
+      awaitQuery(
+        List.of(row1),
+        outParameters ->
+          new TestRow(row1.id, outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row1.id)
+          .bind("value", Parameters.out(arrayType)));
+    }
+    finally {
+      tryAwaitExecution(connection.createStatement(
+        "DROP TABLE testOutArrayCall"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP PROCEDURE testOutArrayProcedure"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_OUT_ARRAY"));
+      tryAwaitNone(connection.close());
+    }
+  }
+
+  /**
+   * Verifies behavior for a PL/SQL call having {@code ARRAY} type OUT bind
+   */
+  @Test
+  public void testInOutArrayCall() {
+    Connection connection = awaitOne(sharedConnection());
+    try {
+      awaitExecution(connection.createStatement(
+        "CREATE TYPE TEST_IN_OUT_ARRAY AS ARRAY(8) OF NUMBER"));
+      awaitExecution(connection.createStatement(
+        "CREATE TABLE testInOutArrayCall(id NUMBER, value TEST_IN_OUT_ARRAY)"));
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE PROCEDURE testInOutArrayProcedure (" +
+          "   inId IN NUMBER," +
+          "   inOutArray IN OUT TEST_IN_OUT_ARRAY)" +
+          " IS" +
+          " newValue TEST_IN_OUT_ARRAY;" +
+          " BEGIN" +
+          "" +
+          " newValue := TEST_IN_OUT_ARRAY();" +
+          " newValue.extend(inOutArray.count);" +
+          " FOR i IN 1 .. inOutArray.count LOOP" +
+          "   newValue(i) := inOutArray(i);" +
+          " END LOOP;" +
+          "" +
+          " BEGIN" +
+          "   SELECT value INTO inOutArray" +
+          "     FROM testInOutArrayCall" +
+          "     WHERE id = inId;" +
+          "   DELETE FROM testInOutArrayCall WHERE id = inId;" +
+          "   EXCEPTION" +
+          "     WHEN NO_DATA_FOUND THEN" +
+          "       inOutArray := NULL;" +
+          " END;" +
+          "" +
+          " INSERT INTO testInOutArrayCall VALUES (inId, newValue);" +
+          "" +
+          " END;"));
+
+      class TestRow {
+        Long id;
+        Integer[] value;
+        TestRow(Long id, Integer[] value) {
+          this.id = id;
+          this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+          return other instanceof TestRow
+            && Objects.equals(((TestRow) other).id, id)
+            && Objects.deepEquals(((TestRow)other).value, value);
+        }
+
+        @Override
+        public String toString() {
+          return id + ", " + Arrays.toString(value);
+        }
+      }
+
+      OracleR2dbcTypes.ArrayType arrayType =
+        OracleR2dbcTypes.arrayType("TEST_IN_OUT_ARRAY");
+      Statement callStatement = connection.createStatement(
+        "BEGIN testInOutArrayProcedure(:id, :value); END;");
+
+      // Expect a NULL out parameter the first time a row is inserted
+      TestRow row = new TestRow(0L, new Integer[]{1, 2, 3});
+      awaitQuery(
+        List.of(Optional.empty()),
+        outParameters -> {
+          assertNull(outParameters.get("value"));
+          assertNull(outParameters.get("value", int[].class));
+          assertNull(outParameters.get("value", Integer[].class));
+          return Optional.empty();
+        },
+        callStatement
+          .bind("id", row.id)
+          .bind("value", Parameters.inOut(arrayType, row.value)));
+
+      // Update the row and expect an out parameter with the previous value
+      TestRow row1 = new TestRow(row.id, new Integer[]{4, 5, 6});
+      awaitQuery(
+        List.of(row),
+        outParameters ->
+          new TestRow(
+            row.id,
+            outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row.id)
+          .bind("value", Parameters.inOut(arrayType, row1.value)));
+
+      // Update the row again and expect an out parameter with the previous
+      // value
+      TestRow row2 = new TestRow(row.id, new Integer[]{7, 8, 9});
+      awaitQuery(
+        List.of(row1),
+        outParameters ->
+          new TestRow(
+            row.id,
+            outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row.id)
+          .bind("value", Parameters.inOut(arrayType, row2.value)));
+    }
+    finally {
+      tryAwaitExecution(connection.createStatement(
+        "DROP TABLE testInOutArrayCall"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP PROCEDURE testInOutArrayProcedure"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_IN_OUT_ARRAY"));
+      tryAwaitNone(connection.close());
     }
   }
 

--- a/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
+++ b/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
@@ -653,7 +653,7 @@ public class TypeMappingTest {
         i -> {
           long[] moreLongs = new long[longs.length];
           for (int j = 0; j < longs.length; j++)
-            moreLongs[j] = (long)(longs[j] + i);
+            moreLongs[j] = longs[j] + i;
           return moreLongs;
         },
         false,


### PR DESCRIPTION
This branch adds support for ARRAY types in Oracle Database.

The `bind` methods of `Statement` may now be used to bind Java arrays to the ARRAY type. Likewise, the `get` methods of `Readable` may now be used to get ARRAY values as Java arrays.

Oracle Database only supports ARRAY as a user defined type. In order to bind a value to an ARRAY, the name of the user defined type must be known to the driver. Oracle R2DBC will extend the R2DBC SPI with a new `Type` that represents a named ARRAY type: `oracle.r2dbc.OracleR2DBCTypes.ArrayType`.

Instances of `ArrayType` must be used to create io.r2dbc.spi.Parameter objects that bind Java arrays to ARRAY values.

See changes in the README.md for usage examples.