### PR TITLE
DN Matching Option Fix

### DIFF
--- a/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
@@ -400,11 +400,18 @@ final class OracleReactiveJdbcAdapter implements ReactiveJdbcAdapter {
         PORT, options, Integer.class, Integer::valueOf);
       Object serviceName = options.getValue(DATABASE);
 
-      return String.format("jdbc:oracle:thin:@%s%s%s%s",
+      Object dnMatch =
+        options.getValue(OracleR2dbcOptions.TLS_SERVER_DN_MATCH);
+
+      return String.format("jdbc:oracle:thin:@%s%s%s%s?%s=%s",
         protocol == null ? "" : protocol + "://",
         host,
         port != null ? (":" + port) : "",
-        serviceName != null ? ("/" + serviceName) : "");
+        serviceName != null ? ("/" + serviceName) : "",
+        // Workaround for Oracle JDBC bug #33150409. DN matching is enabled
+        // unless the property is set as a query parameter.
+        OracleR2dbcOptions.TLS_SERVER_DN_MATCH.name(),
+        dnMatch == null ? "false" : dnMatch);
     }
   }
 

--- a/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
@@ -634,8 +634,8 @@ public class OracleReactiveJdbcAdapterTest {
       // than a name (Europe/Warsaw).
       Connection connection = awaitOne(ConnectionFactories.get(
         ConnectionFactoryOptions.parse(format(
-          "r2dbc:oracle://%s:%d/%s?oracle.jdbc.timezoneAsRegion=false",
-          host(), port(), serviceName()))
+          "r2dbc:oracle:%s://%s:%d/%s?oracle.jdbc.timezoneAsRegion=false",
+          protocol(), host(), port(), serviceName()))
           .mutate()
           .option(USER, user())
           .option(PASSWORD, password())

--- a/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapterTest.java
@@ -634,8 +634,9 @@ public class OracleReactiveJdbcAdapterTest {
       // than a name (Europe/Warsaw).
       Connection connection = awaitOne(ConnectionFactories.get(
         ConnectionFactoryOptions.parse(format(
-          "r2dbc:oracle:%s://%s:%d/%s?oracle.jdbc.timezoneAsRegion=false",
-          protocol(), host(), port(), serviceName()))
+          "r2dbc:oracle%s://%s:%d/%s?oracle.jdbc.timezoneAsRegion=false",
+          protocol() == null ? "" : ":" + protocol(),
+          host(), port(), serviceName()))
           .mutate()
           .option(USER, user())
           .option(PASSWORD, password())


### PR DESCRIPTION
This branch works around Oracle JDBC behavior, in which the connection property to configure DN matching gets ignored.
The workaround is to configure the property in the query section of the JDBC URL.