### PR TITLE
OBJECT Types

### DIFF
--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -81,6 +81,6 @@ echo "HOST=localhost" >> src/test/resources/config.properties
 echo "PORT=1521" >> src/test/resources/config.properties
 echo "USER=test" >> src/test/resources/config.properties
 echo "PASSWORD=test" >> src/test/resources/config.properties
-echo "CONNECT_TIMEOUT=180" >> src/test/resources/config.properties
-echo "SQL_TIMEOUT=180" >> src/test/resources/config.properties
+echo "CONNECT_TIMEOUT=240" >> src/test/resources/config.properties
+echo "SQL_TIMEOUT=240" >> src/test/resources/config.properties
 mvn clean compile test

--- a/.github/workflows/test.sh
+++ b/.github/workflows/test.sh
@@ -81,6 +81,6 @@ echo "HOST=localhost" >> src/test/resources/config.properties
 echo "PORT=1521" >> src/test/resources/config.properties
 echo "USER=test" >> src/test/resources/config.properties
 echo "PASSWORD=test" >> src/test/resources/config.properties
-echo "CONNECT_TIMEOUT=120" >> src/test/resources/config.properties
-echo "SQL_TIMEOUT=120" >> src/test/resources/config.properties
+echo "CONNECT_TIMEOUT=180" >> src/test/resources/config.properties
+echo "SQL_TIMEOUT=180" >> src/test/resources/config.properties
 mvn clean compile test

--- a/README.md
+++ b/README.md
@@ -618,6 +618,120 @@ Publisher<Integer[]> arrayMapExample(Result result) {
 }
 ```
 
+### OBJECT
+Oracle Database supports `OBJECT` as a user defined type. A `CREATE TYPE`
+command is used to define an `OBJECT` type:
+```sql
+CREATE TYPE PET AS OBJECT(
+  name VARCHAR(128),
+  species VARCHAR(128),
+  weight NUMBER,
+  birthday DATE)
+```
+Oracle R2DBC defines `oracle.r2dbc.OracleR2dbcType.ObjectType` as a `Type` for
+representing user defined `OBJECT` types. A `Parameter` with a type of
+`ObjectType` may be used to bind `OBJECT` values to a `Statement`.
+
+Use an `Object[]` to bind the attribute values of an `OBJECT` by index:
+```java
+Publisher<Result> objectArrayBindExample(Connection connection) {
+  Statement statement =
+    connection.createStatement("INSERT INTO petTable VALUES (:petObject)");
+
+  // Bind the attributes of the PET OBJECT defined above
+  ObjectType objectType = OracleR2dbcTypes.objectType("PET");
+  Object[] attributeValues = {
+    "Derby",
+    "Dog",
+    22.8,
+    LocalDate.of(2015, 11, 07)
+  };
+  statement.bind("petObject", Parameters.in(objectType, attributeValues));
+
+  return statement.execute();
+}
+```
+
+Use a `Map<String,Object>` to bind the attribute values of an `OBJECT` by name:
+```java
+Publisher<Result> objectMapBindExample(Connection connection) {
+  Statement statement =
+    connection.createStatement("INSERT INTO petTable VALUES (:petObject)");
+
+  // Bind the attributes of the PET OBJECT defined above
+  ObjectType objectType = OracleR2dbcTypes.objectType("PET");
+  Map<String,Object> attributeValues = Map.of(
+    "name", "Derby",
+    "species", "Dog",
+    "weight", 22.8,
+    "birthday", LocalDate.of(2015, 11, 07));
+  statement.bind("petObject", Parameters.in(objectType, attributeValues));
+
+  return statement.execute();
+}
+```
+A `Parameter` with a type of `ObjectType` must be used when binding OUT
+parameters of `OBJECT` types for a PL/SQL call:
+```java
+Publisher<Result> objectOutBindExample(Connection connection) {
+  Statement statement =
+    connection.createStatement("BEGIN; getPet(:petObject); END;");
+
+  ObjectType objectType = OracleR2dbcTypes.objectType("PET");
+  statement.bind("petObject", Parameters.out(objectType));
+
+  return statement.execute();
+}
+```
+`OBJECT` values may be consumed from a `Row` or `OutParameter` as an
+`oracle.r2dbc.OracleR2dbcObject`. The `OracleR2dbcObject` interface is a subtype
+of `io.r2dbc.spi.Readable`. Attribute values may be accessed using the standard
+`get` methods of `Readable`. The `get` methods of `OracleR2dbcObject` support
+alll SQL to Java type mappings defined by the
+[R2DBC Specification](https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/#datatypes.mapping):
+```java
+Publisher<Pet> objectMapExample(Result result) {
+  return result.map(row -> {
+    OracleR2dbcObject oracleObject = row.get(0, OracleR2dbcObject.class); 
+    return new Pet(
+      oracleObject.get("name", String.class),
+      oracleObject.get("species", String.class),
+      oracleObject.get("weight", Float.class),
+      oracleObject.get("birthday", LocalDate.class));
+  });
+}
+```
+
+Instances of `OracleR2dbcObject` may be passed directly to `Statement` bind 
+methods:
+```java
+Publisher<Result> objectBindExample(
+  OracleR2dbcObject oracleObject, Connection connection) {
+  Statement statement =
+    connection.createStatement("INSERT INTO petTable VALUES (:petObject)");
+  
+  statement.bind("petObject", oracleObject);
+
+  return statement.execute();
+}
+```
+Attribute metadata is exposed by the `getMetadata` method of
+`OracleR2dbcObject`:
+```java
+void printObjectMetadata(OracleR2dbcObject oracleObject) {
+  OracleR2dbcObjectMetadata metadata = oracleObject.getMetadata();
+  OracleR2dbcTypes.ObjectType objectType = metadata.getObjectType();
+  
+  System.out.println("Object Type: " + objectType);
+  metadata.getAttributeMetadatas()
+    .stream()
+    .forEach(attributeMetadata -> {
+      System.out.println("\tAttribute Name: " + attributeMetadata.getName()));
+      System.out.println("\tAttribute Type: " + attributeMetadata.getType()));
+    });
+}
+```
+
 ### REF Cursor
 Use the `oracle.r2dbc.OracleR2dbcTypes.REF_CURSOR` type to bind `SYS_REFCURSOR` out 
 parameters:

--- a/README.md
+++ b/README.md
@@ -553,6 +553,29 @@ prefetched entirely, a smaller prefetch size can be configured using the
 option, and the LOB can be consumed as a stream. By mapping LOB columns to 
 `Blob` or `Clob` objects, the content can be consumed as a reactive stream. 
 
+### ARRAY
+Oracle Database supports `ARRAY` as a user defined type only. A `CREATE TYPE` 
+command is used to define an `ARRAY` type:
+```sql
+CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+```
+Oracle R2DBC defines `oracle.r2dbc.OracleR2dbcType.ArrayType` as a `Type` for
+representing user defined `ARRAY` types. A `Parameter` with an type of
+`ArrayType` must be used when binding array values to a `Statement` 
+```java
+Publisher<Result> arrayBindExample(Connection connection) {
+  Statement statement =
+    connection.createStatement("INSERT INTO example VALUES (:array_bind)");
+
+  // Use the name defined for an ARRAY type:
+  // CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+  ArrayType arrayType = OracleR2dbcTypes.arrayType("MY_ARRAY");
+  Integer[] arrayValues = {1, 2, 3};
+  statement.bind("arrayBind", Parameters.in(arrayType, arrayValues));
+
+  return statement.execute();
+}
+```
 ## Secure Programming Guidelines
 The following security related guidelines should be adhered to when programming
 with the Oracle R2DBC Driver.

--- a/README.md
+++ b/README.md
@@ -560,8 +560,8 @@ command is used to define an `ARRAY` type:
 CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
 ```
 Oracle R2DBC defines `oracle.r2dbc.OracleR2dbcType.ArrayType` as a `Type` for
-representing user defined `ARRAY` types. A `Parameter` with an type of
-`ArrayType` must be used when binding array values to a `Statement` 
+representing user defined `ARRAY` types. A `Parameter` with a type of
+`ArrayType` must be used when binding array values to a `Statement`.
 ```java
 Publisher<Result> arrayBindExample(Connection connection) {
   Statement statement =
@@ -574,6 +574,30 @@ Publisher<Result> arrayBindExample(Connection connection) {
   statement.bind("arrayBind", Parameters.in(arrayType, arrayValues));
 
   return statement.execute();
+}
+```
+A `Parameter` with a type of `ArrayType` must also be used when binding OUT
+parameters of a PL/SQL call.
+```java
+Publisher<Result> arrayOutBindExample(Connection connection) {
+  Statement statement =
+    connection.createStatement("BEGIN; exampleCall(:array_bind); END;");
+
+  // Use the name defined for an ARRAY type:
+  // CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+  ArrayType arrayType = OracleR2dbcTypes.arrayType("MY_ARRAY");
+  statement.bind("arrayBind", Parameters.out(arrayType));
+
+  return statement.execute();
+}
+```
+`ARRAY` values may be consumed from a `Row` or `OutParameter` as a Java array.
+The element type of the Java array may be any Java type that is supported as
+a mapping for the SQL type of the `ARRAY`. For instance, if the `ARRAY` type is
+`NUMBER`, then a `Integer[]` mapping is supported:
+```java
+Publisher<Integer[]> arrayMapExample(Result result) {
+  return result.map(readable -> readable.get("arrayValue", Integer[].class));
 }
 ```
 ## Secure Programming Guidelines

--- a/src/main/java/oracle/r2dbc/OracleR2dbcObject.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcObject.java
@@ -1,0 +1,6 @@
+package oracle.r2dbc;
+
+public interface OracleR2dbcObject extends io.r2dbc.spi.Readable {
+
+  OracleR2dbcObjectMetadata getMetadata();
+}

--- a/src/main/java/oracle/r2dbc/OracleR2dbcObject.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcObject.java
@@ -3,4 +3,5 @@ package oracle.r2dbc;
 public interface OracleR2dbcObject extends io.r2dbc.spi.Readable {
 
   OracleR2dbcObjectMetadata getMetadata();
+
 }

--- a/src/main/java/oracle/r2dbc/OracleR2dbcObjectMetadata.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcObjectMetadata.java
@@ -5,7 +5,18 @@ import io.r2dbc.spi.ReadableMetadata;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+/**
+ * Represents the metadata for attributes of an OBJECT. Metadata for attributes
+ * can either be retrieved by index or by name. Attribute indexes are
+ * {@code 0}-based. Retrieval by attribute name is case-insensitive.
+ */
 public interface OracleR2dbcObjectMetadata {
+
+  /**
+   * Returns the type of the OBJECT which metadata is provided for.
+   * @return The type of the OBJECT. Not null.
+   */
+  OracleR2dbcTypes.ObjectType getObjectType();
 
   /**
    * Returns the {@link ReadableMetadata} for one attribute.

--- a/src/main/java/oracle/r2dbc/OracleR2dbcObjectMetadata.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcObjectMetadata.java
@@ -1,0 +1,38 @@
+package oracle.r2dbc;
+
+import io.r2dbc.spi.ReadableMetadata;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+public interface OracleR2dbcObjectMetadata {
+
+  /**
+   * Returns the {@link ReadableMetadata} for one attribute.
+   *
+   * @param index the attribute index starting at 0
+   * @return the {@link ReadableMetadata} for one attribute. Not null.
+   * @throws IndexOutOfBoundsException if {@code index} is out of range
+   * (negative or equals/exceeds {@code getParameterMetadatas().size()})
+   */
+  ReadableMetadata getAttributeMetadata(int index);
+
+  /**
+   * Returns the {@link ReadableMetadata} for one attribute.
+   *
+   * @param name the name of the attribute. Not null. Parameter names are
+   * case-insensitive.
+   * @return the {@link ReadableMetadata} for one attribute. Not null.
+   * @throws IllegalArgumentException if {@code name} is {@code null}
+   * @throws NoSuchElementException if there is no attribute with the
+   * {@code name}
+   */
+  ReadableMetadata getAttributeMetadata(String name);
+
+  /**
+   * Returns the {@link ReadableMetadata} for all attributes.
+   *
+   * @return the {@link ReadableMetadata} for all attributes. Not null.
+   */
+  List<? extends ReadableMetadata> getAttributeMetadatas();
+}

--- a/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
@@ -104,6 +104,12 @@ public final class OracleR2dbcTypes {
     new TypeImpl(Result.class, "SYS_REFCURSOR");
 
   /**
+   * A user defined OBJECT type.
+   */
+  public static final Type OBJECT =
+    new TypeImpl(OracleR2dbcObject.class, "OBJECT");
+
+  /**
    * <p>
    * Creates an {@link ArrayType} representing a user defined {@code ARRAY}
    * type. The {@code name} passed to this method must identify the name of a
@@ -135,6 +141,10 @@ public final class OracleR2dbcTypes {
    */
   public static ArrayType arrayType(String name) {
     return new ArrayTypeImpl(Objects.requireNonNull(name, "name is null"));
+  }
+
+  public static ObjectType objectType(String name) {
+    return new ObjectTypeImpl(Objects.requireNonNull(name, "name is null"));
   }
 
   /**
@@ -179,6 +189,31 @@ public final class OracleR2dbcTypes {
     String getName();
   }
 
+  public interface ObjectType extends Type {
+
+    /**
+     * {@inheritDoc}
+     * Returns {@code Object[].class}, which is the standard mapping for
+     * {@link R2dbcType#COLLECTION}. The true default type mapping is the array
+     * variant of the default mapping for the element type of the {@code ARRAY}.
+     * For instance, an {@code ARRAY} of {@code VARCHAR} maps to a
+     * {@code String[]} by default.
+     */
+    @Override
+    Class<?> getJavaType();
+
+    /**
+     * {@inheritDoc}
+     * Returns the name of this user defined {@code ARRAY} type. For instance,
+     * this method returns "MY_ARRAY" if the type is declared as:
+     * <pre>{@code
+     * CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+     * }</pre>
+     */
+    @Override
+    String getName();
+  }
+
   /** Concrete implementation of the {@code ArrayType} interface */
   private static final class ArrayTypeImpl
     extends TypeImpl implements ArrayType {
@@ -192,6 +227,23 @@ public final class OracleR2dbcTypes {
      */
     ArrayTypeImpl(String name) {
       super(Object[].class, name);
+    }
+  }
+
+  /** Concrete implementation of the {@code ObjectType} interface */
+  private static final class ObjectTypeImpl
+    extends TypeImpl implements ObjectType {
+
+    /**
+     * Constructs an ARRAY type with the given {@code name}. The constructed
+     * {@code ObjectType} as a default Java type mapping of
+     * {@code Object[].class}. This is consistent with the standard
+     * {@link R2dbcType#COLLECTION} type.
+     * @param name User defined name of the type. Not null.
+     */
+    ObjectTypeImpl(String name) {
+      // TODO: Consider defining Readable.class as the default type mapping.
+      super(Object.class, name);
     }
   }
 

--- a/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
@@ -106,8 +106,8 @@ public final class OracleR2dbcTypes {
    * {@code CREATE TYPE} command that created the type used an "enquoted" type
    * name.
    * </p><p>
-   * The {@code ArrayType} object returned by this method may be used to a
-   * {@link Parameter} that binds an array value to a {@link Statement}.
+   * The {@code ArrayType} object returned by this method may be used to create
+   * a {@link Parameter} that binds an array value to a {@link Statement}.
    * </p><pre>{@code
    * Publisher<Result> arrayBindExample(Connection connection) {
    *   Statement statement =

--- a/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
@@ -20,6 +20,9 @@
 */
 package oracle.r2dbc;
 
+import io.r2dbc.spi.Parameter;
+import io.r2dbc.spi.R2dbcType;
+import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.Type;
 import oracle.sql.json.OracleJsonObject;
 
@@ -28,6 +31,7 @@ import java.sql.RowId;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.Period;
+import java.util.Objects;
 
 /**
  * SQL types supported by Oracle Database that are not defined as standard types
@@ -93,9 +97,101 @@ public final class OracleR2dbcTypes {
     new TypeImpl(LocalDateTime.class, "TIMESTAMP WITH LOCAL TIME ZONE");
 
   /**
+   * <p>
+   * Creates an {@link ArrayType} representing a user defined {@code ARRAY}
+   * type. The {@code name} passed to this method must identify the name of a
+   * user defined {@code ARRAY} type.
+   * </p><p>
+   * Typically, the name passed to this method should be UPPER CASE, unless the
+   * {@code CREATE TYPE} command that created the type used an "enquoted" type
+   * name.
+   * </p><p>
+   * The {@code ArrayType} object returned by this method may be used to a
+   * {@link Parameter} that binds an array value to a {@link Statement}.
+   * </p><pre>{@code
+   * Publisher<Result> arrayBindExample(Connection connection) {
+   *   Statement statement =
+   *     connection.createStatement("INSERT INTO example VALUES (:array_bind)");
+   *
+   *   // Use the name defined for an ARRAY type:
+   *   // CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+   *   ArrayType arrayType = OracleR2dbcTypes.arrayType("MY_ARRAY");
+   *   Integer[] arrayValues = {1, 2, 3};
+   *   statement.bind("arrayBind", Parameters.in(arrayType, arrayValues));
+   *
+   *   return statement.execute();
+   * }
+   * }</pre>
+   * @param name Name of a user defined ARRAY type. Not null.
+   * @return A {@code Type} object representing the user defined ARRAY type. Not
+   * null.
+   */
+  public static ArrayType arrayType(String name) {
+    return new ArrayTypeImpl(Objects.requireNonNull(name, "name is null"));
+  }
+
+  /**
+   * Extension of the standard {@link Type} interface used to represent user
+   * defined ARRAY types. An instance of {@code ArrayType} must be used when
+   * binding an array value to a {@link Statement} created by the Oracle R2DBC
+   * Driver.
+   * </p><p>
+   * Oracle Database does not support an anonymous {@code ARRAY} type, which is
+   * what the standard {@link R2dbcType#COLLECTION} type represents. Oracle
+   * Database only supports {@code ARRAY} types which are declared as a user
+   * defined type, as in:
+   * <pre>{@code
+   * CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+   * }</pre>
+   * In order to bind an array, the name of a user defined ARRAY type must
+   * be known to Oracle R2DBC. Instances of {@code ArrayType} retain the name
+   * that is provided to the {@link #arrayType(String)} factory method.
+   */
+  public interface ArrayType extends Type {
+
+    /**
+     * {@inheritDoc}
+     * Returns {@code Object[].class}, which is the standard mapping for
+     * {@link R2dbcType#COLLECTION}. The true default type mapping is the array
+     * variant of the default mapping for the element type of the {@code ARRAY}.
+     * For instance, an {@code ARRAY} of {@code VARCHAR} maps to a
+     * {@code String[]} by default.
+     */
+    @Override
+    Class<?> getJavaType();
+
+    /**
+     * {@inheritDoc}
+     * Returns the name of this user defined {@code ARRAY} type. For instance,
+     * this method returns "MY_ARRAY" if the type is declared as:
+     * <pre>{@code
+     * CREATE TYPE MY_ARRAY AS ARRAY(8) OF NUMBER
+     * }</pre>
+     */
+    @Override
+    String getName();
+  }
+
+  /** Concrete implementation of the {@code ArrayType} interface */
+  private static final class ArrayTypeImpl
+    extends TypeImpl implements ArrayType {
+
+    /**
+     * Constructs an ARRAY type with the given {@code name}. The constructed
+     * {@code ArrayType} as a default Java type mapping of
+     * {@code Object[].class}. This is consistent with the standard
+     * {@link R2dbcType#COLLECTION} type.
+     * @param name User defined name of the type. Not null.
+     */
+    ArrayTypeImpl(String name) {
+      super(Object[].class, name);
+    }
+  }
+
+  /**
    * Implementation of the {@link Type} SPI.
    */
-  private static final class TypeImpl implements Type {
+  private static class TypeImpl implements Type {
 
     /**
      * The Java Language mapping of this SQL type.

--- a/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
@@ -104,12 +104,6 @@ public final class OracleR2dbcTypes {
     new TypeImpl(Result.class, "SYS_REFCURSOR");
 
   /**
-   * A user defined OBJECT type.
-   */
-  public static final Type OBJECT =
-    new TypeImpl(OracleR2dbcObject.class, "OBJECT");
-
-  /**
    * <p>
    * Creates an {@link ArrayType} representing a user defined {@code ARRAY}
    * type. The {@code name} passed to this method must identify the name of a
@@ -219,10 +213,9 @@ public final class OracleR2dbcTypes {
     extends TypeImpl implements ArrayType {
 
     /**
-     * Constructs an ARRAY type with the given {@code name}. The constructed
-     * {@code ArrayType} as a default Java type mapping of
-     * {@code Object[].class}. This is consistent with the standard
-     * {@link R2dbcType#COLLECTION} type.
+     * Constructs an ARRAY type with the given {@code name}. {@code Object[]} is
+     * the default mapping of the constructed type. This is consistent with the
+     * standard {@link R2dbcType#COLLECTION} type.
      * @param name User defined name of the type. Not null.
      */
     ArrayTypeImpl(String name) {
@@ -235,15 +228,12 @@ public final class OracleR2dbcTypes {
     extends TypeImpl implements ObjectType {
 
     /**
-     * Constructs an ARRAY type with the given {@code name}. The constructed
-     * {@code ObjectType} as a default Java type mapping of
-     * {@code Object[].class}. This is consistent with the standard
-     * {@link R2dbcType#COLLECTION} type.
+     * Constructs an OBJECT type with the given {@code name}.
+     * {@code OracleR2dbcObject} is the default mapping of the constructed type.
      * @param name User defined name of the type. Not null.
      */
     ObjectTypeImpl(String name) {
-      // TODO: Consider defining Readable.class as the default type mapping.
-      super(Object.class, name);
+      super(OracleR2dbcObject.class, name);
     }
   }
 
@@ -310,6 +300,19 @@ public final class OracleR2dbcTypes {
     @Override
     public String toString() {
       return getName();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (! (other instanceof Type))
+        return false;
+
+      return sqlName.equals(((Type)other).getName());
+    }
+
+    @Override
+    public int hashCode() {
+      return sqlName.hashCode();
     }
   }
 

--- a/src/main/java/oracle/r2dbc/impl/OracleR2dbcExceptions.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleR2dbcExceptions.java
@@ -81,6 +81,7 @@ final class OracleR2dbcExceptions {
       return obj;
   }
 
+
   /**
    * Checks if a {@code jdbcConnection} is open, and throws an exception if the
    * check fails.

--- a/src/main/java/oracle/r2dbc/impl/OracleReadableImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReadableImpl.java
@@ -1059,13 +1059,6 @@ class OracleReadableImpl implements io.r2dbc.spi.Readable {
     private final OracleR2dbcObjectMetadata metadata;
 
     /**
-     * JDBC readable that backs this object. It is retained with this field to
-     * implement equals and hashcode without having to convert between the
-     * default JDBC object mappings and those of R2DBC.
-     */
-    private final StructJdbcReadable structJdbcReadable;
-
-    /**
      * <p>
      * Constructs a new set of out parameters that supplies values of a
      * {@code jdbcReadable} and obtains metadata of the values from
@@ -1086,31 +1079,11 @@ class OracleReadableImpl implements io.r2dbc.spi.Readable {
       super(
         jdbcConnection, dependentCounter, structJdbcReadable, metadata, adapter);
       this.metadata = metadata;
-      this.structJdbcReadable = structJdbcReadable;
     }
 
     @Override
     public OracleR2dbcObjectMetadata getMetadata() {
       return metadata;
-    }
-
-    @Override
-    public boolean equals(Object other) {
-      if (!(other instanceof OracleR2dbcObjectImpl))
-        return super.equals(other);
-
-      OracleR2dbcObjectImpl otherObject = (OracleR2dbcObjectImpl) other;
-      if (! readablesMetadata.equals(otherObject.metadata))
-        return false;
-
-      return Arrays.deepEquals(
-        structJdbcReadable.attributes,
-        otherObject.structJdbcReadable.attributes);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(readablesMetadata, structJdbcReadable);
     }
 
     @Override
@@ -1122,6 +1095,7 @@ class OracleReadableImpl implements io.r2dbc.spi.Readable {
     }
   }
 
+  /** A {@code JdbcReadable} backed by a java.sql.Struct */
   private final class StructJdbcReadable implements JdbcReadable {
 
     /** Attributes of the Struct, mapped to their default Java type for JDBC */

--- a/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
@@ -263,6 +263,11 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
    */
   static OutParameterMetadata createParameterMetadata(
     String name, Type type) {
+
+    // Translate the Oracle specific ArrayType to the standard COLLECTION type
+    if (type instanceof OracleR2dbcTypes.ArrayType)
+      type = R2dbcType.COLLECTION;
+
     return new OracleOutParameterMetadataImpl(
       type, name, Nullability.NULLABLE, null, null);
   }

--- a/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
@@ -320,7 +320,7 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
       return new OracleColumnMetadataImpl(type, name, nullability,
         LOCAL_DATE_PRECISION, null);
     }
-    else if (type == R2dbcType.TIMESTAMP
+    if (type == R2dbcType.TIMESTAMP
       || type == OracleR2dbcTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
       // For the TIMESTAMP types, use the length of LocalDateTime.toString() as
       // the precision. Use the scale from JDBC, even if it's 0 because a

--- a/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReadableMetadataImpl.java
@@ -23,6 +23,7 @@ package oracle.r2dbc.impl;
 
 import java.sql.ResultSetMetaData;
 import java.sql.SQLType;
+import java.sql.Types;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -34,6 +35,7 @@ import io.r2dbc.spi.OutParameterMetadata;
 import io.r2dbc.spi.R2dbcType;
 import io.r2dbc.spi.ReadableMetadata;
 import io.r2dbc.spi.Type;
+import oracle.jdbc.OracleTypes;
 import oracle.r2dbc.OracleR2dbcTypes;
 
 import static oracle.r2dbc.impl.OracleR2dbcExceptions.fromJdbc;
@@ -249,6 +251,28 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
     return type;
   }
 
+  @Override
+  public boolean equals(Object other) {
+    if (!(other instanceof ReadableMetadata))
+      return false;
+
+    ReadableMetadata otherMetadata = (ReadableMetadata) other;
+    return Objects.equals(type, otherMetadata.getType())
+      && Objects.equals(name, otherMetadata.getName())
+      && Objects.equals(nullability, otherMetadata.getNullability())
+      && Objects.equals(precision, otherMetadata.getPrecision())
+      && Objects.equals(scale, otherMetadata.getScale());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+      type,
+      name,
+      nullability,
+      precision,
+      scale);
+  }
 
   /**
    * Creates {@code ColumnMetadata} for an out parameter. The returned
@@ -261,13 +285,7 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
    * @param type Column type
    * @return Column metadata having {@code name} and {@code type}
    */
-  static OutParameterMetadata createParameterMetadata(
-    String name, Type type) {
-
-    // Translate the Oracle specific ArrayType to the standard COLLECTION type
-    if (type instanceof OracleR2dbcTypes.ArrayType)
-      type = R2dbcType.COLLECTION;
-
+  static OutParameterMetadata createParameterMetadata(String name, Type type) {
     return new OracleOutParameterMetadataImpl(
       type, name, Nullability.NULLABLE, null, null);
   }
@@ -291,8 +309,7 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
 
     int jdbcIndex = index + 1;
 
-    Type type = toR2dbcType(fromJdbc(() ->
-      resultSetMetaData.getColumnType(jdbcIndex)));
+    Type type = getR2dbcType(jdbcIndex, resultSetMetaData);
 
     String name = fromJdbc(() ->
       resultSetMetaData.getColumnName(jdbcIndex));
@@ -320,22 +337,29 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
       return new OracleColumnMetadataImpl(type, name, nullability,
         LOCAL_DATE_PRECISION, null);
     }
-    if (type == R2dbcType.TIMESTAMP
+    else if (type == R2dbcType.TIMESTAMP
       || type == OracleR2dbcTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
       // For the TIMESTAMP types, use the length of LocalDateTime.toString() as
       // the precision. Use the scale from JDBC, even if it's 0 because a
-      // TIMESTAMP may 0 decimal digits.
+      // TIMESTAMP may 0 decimal digits. Oracle JDBC does not support getScale
+      // for struct metadata, so ignore the value it returns (which is 0).
       return new OracleColumnMetadataImpl(type, name, nullability,
         LOCAL_DATE_TIME_PRECISION,
-        fromJdbc(() -> resultSetMetaData.getScale(jdbcIndex)));
+        resultSetMetaData instanceof oracle.jdbc.StructMetaData
+          ? null
+          : fromJdbc(() -> resultSetMetaData.getScale(jdbcIndex)));
     }
     else if (type == R2dbcType.TIMESTAMP_WITH_TIME_ZONE) {
       // For the TIMESTAMP WITH TIMEZONE types, use the length of
       // OffsetDateTime.toString() as the precision. Use the scale from JDBC,
-      // even if it's 0 because a TIMESTAMP may have 0 decimal digits.
+      // even if it's 0 because a TIMESTAMP may have 0 decimal digits. Oracle
+      // JDBC does not support getScale for struct metadata, so ignore the value
+      // it returns (which is 0).
       return new OracleColumnMetadataImpl(type, name, nullability,
         OFFSET_DATE_TIME_PRECISION,
-        fromJdbc(() -> resultSetMetaData.getScale(jdbcIndex)));
+        resultSetMetaData instanceof oracle.jdbc.StructMetaData
+          ? null
+          : fromJdbc(() -> resultSetMetaData.getScale(jdbcIndex)));
     }
     else if (type == R2dbcType.VARBINARY) {
       // Oracle JDBC implements getColumnDisplaySize to return the
@@ -368,6 +392,37 @@ class OracleReadableMetadataImpl implements ReadableMetadata {
         // precision and scale are not applicable.
         precision == 0 ? null : precision,
         scale == 0 ? null : scale);
+    }
+  }
+
+  /**
+   * Returns the type of the column at a 1-based {@code index}. This method
+   * handles the case where the column is a named type, like ARRAY or OBJECT.
+   */
+  private static Type getR2dbcType(
+    int index, ResultSetMetaData resultSetMetaData) {
+    int jdbcType = fromJdbc(() -> resultSetMetaData.getColumnType(index));
+    switch (jdbcType) {
+      case java.sql.Types.ARRAY:
+        return OracleR2dbcTypes.arrayType(fromJdbc(() ->
+          resultSetMetaData.getColumnTypeName(index)));
+      case java.sql.Types.STRUCT:
+        return OracleR2dbcTypes.objectType(fromJdbc(() ->
+          resultSetMetaData.getColumnTypeName(index)));
+      case Types.BINARY:
+        // Oracle JDBC's struct metadata returns BINARY. VARBINARY is the
+        // correct type to describe Oracle's RAW type.
+        return R2dbcType.VARBINARY;
+      case Types.DATE:
+        // Oracle JDBC's struct metadata returns DATE. TIMESTAMP is the correct
+        // type to describe Oracle's DATE type.
+        return R2dbcType.TIMESTAMP;
+      case OracleTypes.TIMESTAMPTZ:
+        // Oracle JDBC's struct metadata returns a proprietary type code. Use
+        // the standard type.
+        return R2dbcType.TIMESTAMP_WITH_TIME_ZONE;
+      default:
+        return SqlTypeMap.toR2dbcType(jdbcType);
     }
   }
 

--- a/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
@@ -478,7 +478,9 @@ abstract class OracleResultImpl implements Result {
 
       // Avoiding object allocating by reusing the same Row object
       ReusableJdbcReadable reusableJdbcReadable = new ReusableJdbcReadable();
-      Row row = createRow(reusableJdbcReadable, metadata, adapter);
+      Row row = createRow(
+        fromJdbc(() -> resultSet.getStatement().getConnection()),
+        reusableJdbcReadable, metadata, adapter);
 
       return adapter.publishRows(resultSet, jdbcReadable -> {
         reusableJdbcReadable.current = jdbcReadable;

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -1374,11 +1374,14 @@ final class OracleStatementImpl implements Statement {
       OracleR2dbcTypes.ArrayType type, Object value) {
 
       final Object jdbcValue;
+      Class<?> componentType = value.getClass().getComponentType();
+      while (componentType.isArray())
+        componentType = componentType.getComponentType();
 
       if (value instanceof byte[]) {
         // Oracle JDBC does not support creating SQL arrays from a byte[], so
         // convert it to an short[].
-        byte[] bytes =  (byte[])value;
+        byte[] bytes = (byte[])value;
         short[] shorts = new short[bytes.length];
         for (int i = 0; i < bytes.length; i++)
           shorts[i] = (short)(0xFF & bytes[i]);
@@ -1596,7 +1599,9 @@ final class OracleStatementImpl implements Statement {
       return Flux.concat(
         super.executeJdbc(),
         Mono.just(createCallResult(
-          createOutParameters(new JdbcOutParameters(), metadata, adapter),
+          createOutParameters(
+            fromJdbc(preparedStatement::getConnection),
+            new JdbcOutParameters(), metadata, adapter),
           adapter)));
     }
 

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -1574,7 +1574,19 @@ final class OracleStatementImpl implements Statement {
         for (int i : outBindIndexes) {
           Type type = ((Parameter) binds[i]).getType();
           SQLType jdbcType = toJdbcType(type);
-          callableStatement.registerOutParameter(i + 1, jdbcType);
+
+          if (type instanceof OracleR2dbcTypes.ArrayType) {
+            // Call registerOutParameter with the user defined type name
+            // returned by ArrayType.getName(). Oracle JDBC throws an exception
+            // if a name is provided for a built-in type, like VARCHAR, etc. So
+            // this branch should only be taken for user defined types, like
+            // ARRAY.
+            callableStatement.registerOutParameter(
+              i + 1, jdbcType, type.getName());
+          }
+          else {
+            callableStatement.registerOutParameter(i + 1, jdbcType);
+          }
         }
       });
     }

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -976,7 +976,20 @@ final class OracleStatementImpl implements Statement {
 
     /**
      * <p>
-     * Sets {@link #binds} on the {@link #preparedStatement}. The
+     * Sets {@link #binds} on the {@link #preparedStatement}, as specified by
+     * {@link #bind(Object[])}. This method is called when this statement is
+     * executed. Subclasess override this method to perform additional actions.
+     * </p>
+     * @return A {@code Publisher} that emits {@code onComplete} when all
+     * {@code binds} have been set.
+     */
+    protected Publisher<Void> bind() {
+      return bind(binds);
+    }
+
+    /**
+     * <p>
+     * Sets the given {@code binds} on the {@link #preparedStatement}. The
      * returned {@code Publisher} completes after all bind values have
      * materialized and been set on the {@code preparedStatement}.
      * </p><p>
@@ -988,10 +1001,6 @@ final class OracleStatementImpl implements Statement {
      * @return A {@code Publisher} that emits {@code onComplete} when all
      * {@code binds} have been set.
      */
-    protected Publisher<Void> bind() {
-      return bind(binds);
-    }
-
     protected final Publisher<Void> bind(Object[] binds) {
       return adapter.getLock().flatMap(() -> {
 

--- a/src/main/java/oracle/r2dbc/impl/ReadablesMetadata.java
+++ b/src/main/java/oracle/r2dbc/impl/ReadablesMetadata.java
@@ -26,6 +26,9 @@ import io.r2dbc.spi.OutParameterMetadata;
 import io.r2dbc.spi.OutParametersMetadata;
 import io.r2dbc.spi.ReadableMetadata;
 import io.r2dbc.spi.RowMetadata;
+import oracle.jdbc.OracleStruct;
+import oracle.jdbc.OracleTypeMetaData;
+import oracle.r2dbc.OracleR2dbcObjectMetadata;
 
 import java.sql.ResultSetMetaData;
 import java.util.Collection;
@@ -95,15 +98,20 @@ class ReadablesMetadata<T extends ReadableMetadata> {
    */
   static RowMetadataImpl createRowMetadata(
     ResultSetMetaData resultSetMetaData) {
-    int columnCount = fromJdbc(resultSetMetaData::getColumnCount);
-    ColumnMetadata[] columnMetadataArray = new ColumnMetadata[columnCount];
+    return new RowMetadataImpl(
+      ReadablesMetadata.toColumnMetadata(resultSetMetaData));
+  }
 
-    for (int i = 0; i < columnCount; i++) {
-      columnMetadataArray[i] =
-        OracleReadableMetadataImpl.createColumnMetadata(resultSetMetaData, i);
-    }
-
-    return new RowMetadataImpl(columnMetadataArray);
+  /**
+   * Creates {@code OracleR2dbcObjectMetadata} that supplies attribute metadata
+   * from a JDBC {@code OracleStruct} object.
+   */
+  static OracleR2dbcObjectMetadataImpl createAttributeMetadata(
+    OracleStruct oracleStruct) {
+    return new OracleR2dbcObjectMetadataImpl(
+      ReadablesMetadata.toColumnMetadata(fromJdbc(() ->
+        ((OracleTypeMetaData.Struct)oracleStruct.getOracleMetaData())
+          .getMetaData())));
   }
 
   /**
@@ -115,6 +123,24 @@ class ReadablesMetadata<T extends ReadableMetadata> {
   static OutParametersMetadataImpl createOutParametersMetadata(
     OutParameterMetadata[] metadata) {
     return new OutParametersMetadataImpl(metadata);
+  }
+
+  /**
+   * Converts JDBC {@code ResultSetMetaData} into an array of
+   * {@code ColumnMetadata}
+   */
+  private static ColumnMetadata[] toColumnMetadata(
+    ResultSetMetaData resultSetMetaData) {
+
+    int columnCount = fromJdbc(resultSetMetaData::getColumnCount);
+    ColumnMetadata[] columnMetadataArray = new ColumnMetadata[columnCount];
+
+    for (int i = 0; i < columnCount; i++) {
+      columnMetadataArray[i] =
+        OracleReadableMetadataImpl.createColumnMetadata(resultSetMetaData, i);
+    }
+
+    return columnMetadataArray;
   }
 
   /**
@@ -267,6 +293,38 @@ class ReadablesMetadata<T extends ReadableMetadata> {
 
     @Override
     public List<? extends OutParameterMetadata> getParameterMetadatas() {
+      return getList();
+    }
+  }
+
+  static final class OracleR2dbcObjectMetadataImpl
+    extends ReadablesMetadata<ReadableMetadata>
+    implements OracleR2dbcObjectMetadata {
+
+    /**
+     * Constructs a new instance which supplies metadata from an array of {@code
+     * columnMetadata}.
+     *
+     * @param attributeMetadata Metadata from each column in a row. Not null.
+     *   Retained. Not modified.
+     */
+    private OracleR2dbcObjectMetadataImpl(
+      ReadableMetadata[] attributeMetadata) {
+      super(attributeMetadata);
+    }
+
+    @Override
+    public ReadableMetadata getAttributeMetadata(int index) {
+      return get(index);
+    }
+
+    @Override
+    public ReadableMetadata getAttributeMetadata(String name) {
+      return get(name);
+    }
+
+    @Override
+    public List<? extends ReadableMetadata> getAttributeMetadatas() {
       return getList();
     }
   }

--- a/src/main/java/oracle/r2dbc/impl/SqlTypeMap.java
+++ b/src/main/java/oracle/r2dbc/impl/SqlTypeMap.java
@@ -23,6 +23,7 @@ package oracle.r2dbc.impl;
 import io.r2dbc.spi.R2dbcType;
 import io.r2dbc.spi.Type;
 import oracle.jdbc.OracleType;
+import oracle.r2dbc.OracleR2dbcObject;
 import oracle.r2dbc.OracleR2dbcTypes;
 import oracle.sql.json.OracleJsonObject;
 
@@ -100,8 +101,7 @@ final class SqlTypeMap {
       entry(JDBCType.TINYINT, R2dbcType.TINYINT),
       entry(JDBCType.VARBINARY, R2dbcType.VARBINARY),
       entry(JDBCType.VARCHAR, R2dbcType.VARCHAR),
-      entry(JDBCType.REF_CURSOR, OracleR2dbcTypes.REF_CURSOR),
-      entry(JDBCType.STRUCT, OracleR2dbcTypes.OBJECT)
+      entry(JDBCType.REF_CURSOR, OracleR2dbcTypes.REF_CURSOR)
     );
 
   /**
@@ -168,14 +168,19 @@ final class SqlTypeMap {
       // Primitive array mappings supported by OracleArray. Primitive arrays are
       // not subtypes of Object[], which is listed for SQLType.ARRAY above. The
       // primitive array types must be explicitly listed here.
-      entry(boolean[].class, OracleType.VARRAY),
+      entry(boolean[].class, JDBCType.ARRAY),
       // byte[] is mapped to RAW by default
-      // entry(byte[].class, OracleType.VARRAY),
-      entry(short[].class, OracleType.VARRAY),
-      entry(int[].class, OracleType.VARRAY),
-      entry(long[].class, OracleType.VARRAY),
-      entry(float[].class, OracleType.VARRAY),
-      entry(double[].class, OracleType.VARRAY)
+      // entry(byte[].class, JDBCType.ARRAY),
+      entry(short[].class, JDBCType.ARRAY),
+      entry(int[].class, JDBCType.ARRAY),
+      entry(long[].class, JDBCType.ARRAY),
+      entry(float[].class, JDBCType.ARRAY),
+      entry(double[].class, JDBCType.ARRAY),
+
+      // Support binding OracleR2dbcReadable, Object[], and Map<String, Object>
+      // to OBJECT (ie: STRUCT)
+      entry(Map.class, JDBCType.STRUCT),
+      entry(OracleR2dbcObject.class, JDBCType.STRUCT)
     );
 
   /**
@@ -197,12 +202,6 @@ final class SqlTypeMap {
    * @return An R2DBC SQL type. May be null.
    */
   static Type toR2dbcType(int jdbcTypeNumber) {
-
-    // Always represent an Oracle DATE as the standard TIMESTAMP type. Oracle
-    // JDBC's ResultSetMetadata usually does this implicitly. However, if using
-    // OracleTypeMetadata.Struct.getMetadata(), it will still return DATE.
-    if (jdbcTypeNumber == Types.DATE)
-      return R2dbcType.TIMESTAMP;
 
     // Search for a JDBCType with a matching type number
     for (JDBCType jdbcType : JDBCType.values()) {

--- a/src/test/java/oracle/r2dbc/impl/OracleReadableMetadataImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleReadableMetadataImplTest.java
@@ -26,8 +26,12 @@ import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.Nullability;
 import io.r2dbc.spi.Parameters;
 import io.r2dbc.spi.R2dbcType;
+import io.r2dbc.spi.ReadableMetadata;
+import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.Type;
 import oracle.jdbc.OracleType;
+import oracle.r2dbc.OracleR2dbcObject;
+import oracle.r2dbc.OracleR2dbcObjectMetadata;
 import oracle.r2dbc.OracleR2dbcTypes;
 import oracle.sql.json.OracleJsonFactory;
 import oracle.sql.json.OracleJsonObject;
@@ -47,12 +51,19 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.Period;
 import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static java.lang.String.format;
 import static oracle.r2dbc.test.DatabaseConfig.connectTimeout;
 import static oracle.r2dbc.test.DatabaseConfig.databaseVersion;
 import static oracle.r2dbc.test.DatabaseConfig.sharedConnection;
+import static oracle.r2dbc.test.DatabaseConfig.user;
+import static oracle.r2dbc.test.TestUtils.constructObject;
 import static oracle.r2dbc.util.Awaits.awaitExecution;
 import static oracle.r2dbc.util.Awaits.awaitOne;
+import static oracle.r2dbc.util.Awaits.awaitQuery;
 import static oracle.r2dbc.util.Awaits.awaitUpdate;
 import static oracle.r2dbc.util.Awaits.tryAwaitExecution;
 import static oracle.r2dbc.util.Awaits.tryAwaitNone;
@@ -336,17 +347,184 @@ public class OracleReadableMetadataImplTest {
     try {
       awaitExecution(connection.createStatement(
         "CREATE TYPE TEST_ARRAY_TYPE AS ARRAY(3) OF NUMBER"));
+      OracleR2dbcTypes.ArrayType arrayType =
+        OracleR2dbcTypes.arrayType(user().toUpperCase() + ".TEST_ARRAY_TYPE");
 
       verifyColumnMetadata(
-        connection, "TEST_ARRAY_TYPE", JDBCType.ARRAY, R2dbcType.COLLECTION,
+        connection, arrayType.getName(), JDBCType.ARRAY, arrayType,
         null, null, Object[].class,
-        Parameters.in(
-          OracleR2dbcTypes.arrayType("TEST_ARRAY_TYPE"),
-          new Integer[]{0, 1, 2}));
+        Parameters.in(arrayType, new Integer[]{0, 1, 2}));
     }
     finally {
       tryAwaitExecution(connection.createStatement(
         "DROP TYPE TEST_ARRAY_TYPE"));
+      tryAwaitNone(connection.close());
+    }
+  }
+
+  /**
+   * Verifies the implementation of {@link OracleReadableMetadataImpl} for
+   * OBJECT type columns.
+   */
+  @Test
+  public void testObjectTypes() {
+    Connection connection =
+      Mono.from(sharedConnection()).block(connectTimeout());
+    try {
+      // A fully qualified type names to match the names returned by RowMetadata
+      OracleR2dbcTypes.ObjectType objectType = OracleR2dbcTypes.objectType(
+        user().toUpperCase() + ".TEST_OBJECT_TYPE");
+      OracleR2dbcTypes.ObjectType objectType2D = OracleR2dbcTypes.objectType(
+        user().toUpperCase() + ".TEST_OBJECT_TYPE_2D");
+      OracleR2dbcTypes.ArrayType arrayType2D = OracleR2dbcTypes.arrayType(
+        user().toUpperCase() + ".TEST_OBJECT_TYPE_ARRAY_TYPE");
+
+      Type[] attributeTypes = new Type[] {
+        R2dbcType.CHAR,
+        R2dbcType.VARCHAR,
+        R2dbcType.NCHAR,
+        R2dbcType.NVARCHAR,
+        R2dbcType.CLOB,
+        R2dbcType.NCLOB,
+        R2dbcType.VARBINARY,
+        R2dbcType.BLOB,
+        R2dbcType.NUMERIC,
+        OracleR2dbcTypes.BINARY_FLOAT,
+        OracleR2dbcTypes.BINARY_DOUBLE,
+        R2dbcType.TIMESTAMP,
+        R2dbcType.TIMESTAMP,
+        R2dbcType.TIMESTAMP_WITH_TIME_ZONE,
+        OracleR2dbcTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+        objectType2D,
+        arrayType2D,
+      };
+
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE TYPE TEST_OBJECT_TYPE_2D" +
+          " AS OBJECT(value0_2D NUMBER(2, 2))"));
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE TYPE TEST_OBJECT_TYPE_ARRAY_TYPE" +
+          " AS ARRAY(1) OF VARCHAR(10)"));
+
+      String[] attributeNames = IntStream.range(0, attributeTypes.length)
+        .mapToObj(i -> "value" + i)
+        .toArray(String[]::new);
+
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE TYPE TEST_OBJECT_TYPE AS OBJECT(" +
+          "value0 CHAR(10)," +
+          "value1 VARCHAR(10)," +
+          "value2 NCHAR(10)," +
+          "value3 NVARCHAR2(10)," +
+          "value4 CLOB," +
+          "value5 NCLOB," +
+          "value6 RAW(10)," +
+          "value7 BLOB," +
+          "value8 NUMBER(9)," +
+          "value9 BINARY_FLOAT," +
+          "value10 BINARY_DOUBLE," +
+          "value11 DATE," +
+          "value12 TIMESTAMP(9)," +
+          "value13 TIMESTAMP(8) WITH TIME ZONE," +
+          "value14 TIMESTAMP(7) WITH LOCAL TIME ZONE," +
+          "value15 TEST_OBJECT_TYPE_2D," +
+          "value16 TEST_OBJECT_TYPE_ARRAY_TYPE)"));
+
+      OracleR2dbcObject object = constructObject(
+        connection, objectType,
+        Arrays.stream(attributeTypes)
+          .map(Parameters::in)
+          .toArray());
+
+      verifyColumnMetadata(
+        connection, "TEST_OBJECT_TYPE", JDBCType.STRUCT, objectType,
+        null, null, OracleR2dbcObject.class, object);
+
+      // Verify the attribute metadata too.
+      OracleR2dbcObjectMetadata objectMetadata = object.getMetadata();
+      assertEquals(objectType, objectMetadata.getObjectType());
+      // Oracle JDBC does not support returning the precision of character type
+      // attributes. Expect a null precision.
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[0]),
+        attributeNames[0], JDBCType.CHAR, attributeTypes[0],
+        null, null, Nullability.NULLABLE, String.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[1]),
+        attributeNames[1], JDBCType.VARCHAR, attributeTypes[1],
+        null, null, Nullability.NULLABLE, String.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[2]),
+        attributeNames[2], JDBCType.NCHAR, attributeTypes[2],
+        null, null, Nullability.NULLABLE, String.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[3]),
+        attributeNames[3], JDBCType.NVARCHAR, attributeTypes[3],
+        null, null, Nullability.NULLABLE, String.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[4]),
+        attributeNames[4], JDBCType.CLOB, attributeTypes[4],
+        null, null, Nullability.NULLABLE, String.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[5]),
+        attributeNames[5], JDBCType.NCLOB, attributeTypes[5],
+        null, null, Nullability.NULLABLE, String.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[6]),
+        attributeNames[6], JDBCType.VARBINARY, attributeTypes[6],
+        10, null, Nullability.NULLABLE, ByteBuffer.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[7]),
+        attributeNames[7], JDBCType.BLOB, attributeTypes[7],
+        null, null, Nullability.NULLABLE, ByteBuffer.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[8]),
+        attributeNames[8], JDBCType.NUMERIC, attributeTypes[8],
+        9, 0, Nullability.NULLABLE, BigDecimal.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[9]),
+        attributeNames[9], OracleType.BINARY_FLOAT, attributeTypes[9],
+        null, null, Nullability.NULLABLE, Float.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[10]),
+        attributeNames[10], OracleType.BINARY_DOUBLE, attributeTypes[10],
+        null, null, Nullability.NULLABLE, Double.class);
+      // Oracle JDBC does not support returning the scale for data time types.
+      // Expect null.
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[11]),
+        attributeNames[11], JDBCType.TIMESTAMP, attributeTypes[11],
+        29, null, Nullability.NULLABLE, LocalDateTime.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[12]),
+        attributeNames[12], JDBCType.TIMESTAMP, attributeTypes[12],
+        29, null, Nullability.NULLABLE, LocalDateTime.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[13]),
+        attributeNames[13], OracleType.TIMESTAMP_WITH_TIME_ZONE,
+        attributeTypes[13],
+        35, null, Nullability.NULLABLE, OffsetDateTime.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[14]),
+        attributeNames[14], OracleType.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+        attributeTypes[14],
+        29, null, Nullability.NULLABLE, LocalDateTime.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[15]),
+        attributeNames[15], JDBCType.STRUCT, attributeTypes[15],
+        null, null, Nullability.NULLABLE, OracleR2dbcObject.class);
+      verifyMetadata(
+        objectMetadata.getAttributeMetadata(attributeNames[16]),
+        attributeNames[16], JDBCType.ARRAY, attributeTypes[16],
+        null, null, Nullability.NULLABLE, Object[].class);
+    }
+    finally {
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_OBJECT_TYPE"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_OBJECT_TYPE_2D"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_OBJECT_TYPE_ARRAY_TYPE"));
       tryAwaitNone(connection.close());
     }
   }
@@ -396,7 +574,7 @@ public class OracleReadableMetadataImplTest {
     String columnName = "test_123";
     String tableName = "verify_" + columnDdl.replaceAll("[^\\p{Alnum}]", "_");
     awaitExecution(connection.createStatement(
-      String.format("CREATE TABLE "+tableName+"(%s %s)",
+      format("CREATE TABLE "+tableName+"(%s %s)",
         columnName, columnDdl)
     ));
     try {
@@ -411,18 +589,27 @@ public class OracleReadableMetadataImplTest {
           result.map((row, rowMetadata) -> rowMetadata.getColumnMetadata(0))
         ));
 
-      assertEquals(javaType, metadata.getJavaType());
-      // Don't expect Oracle R2DBC to match the column name's case.
-      assertEquals(columnName.toUpperCase(), metadata.getName().toUpperCase());
-      assertEquals(jdbcType, metadata.getNativeTypeMetadata());
-      assertEquals(r2dbcType, metadata.getType());
-      assertEquals(nullability, metadata.getNullability());
-      assertEquals(precision, metadata.getPrecision());
-      assertEquals(scale, metadata.getScale());
+      verifyMetadata(
+        metadata, columnName, jdbcType, r2dbcType, precision, scale,
+        nullability, javaType);
     }
     finally {
       awaitExecution(connection.createStatement("DROP TABLE "+tableName));
     }
+  }
+
+  private void verifyMetadata(
+    ReadableMetadata metadata, String name, SQLType jdbcType,
+    Type r2dbcType, Integer precision, Integer scale, Nullability nullability,
+    Class<?> javaType) {
+    assertEquals(javaType, metadata.getJavaType());
+    // Don't expect Oracle R2DBC to match the column name's case.
+    assertEquals(name.toUpperCase(), metadata.getName().toUpperCase());
+    assertEquals(jdbcType, metadata.getNativeTypeMetadata());
+    assertEquals(r2dbcType, metadata.getType());
+    assertEquals(nullability, metadata.getNullability());
+    assertEquals(precision, metadata.getPrecision());
+    assertEquals(scale, metadata.getScale());
   }
 
 }

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -30,11 +30,11 @@ import io.r2dbc.spi.R2dbcException;
 import io.r2dbc.spi.R2dbcNonTransientException;
 import io.r2dbc.spi.R2dbcType;
 import io.r2dbc.spi.Result;
-import io.r2dbc.spi.Result.Message;
 import io.r2dbc.spi.Result.UpdateCount;
 import io.r2dbc.spi.Statement;
 import io.r2dbc.spi.Type;
 import oracle.r2dbc.OracleR2dbcOptions;
+import oracle.r2dbc.OracleR2dbcTypes;
 import oracle.r2dbc.OracleR2dbcWarning;
 import oracle.r2dbc.test.DatabaseConfig;
 import org.junit.jupiter.api.Test;
@@ -45,9 +45,12 @@ import reactor.core.publisher.Signal;
 
 import java.sql.RowId;
 import java.sql.SQLWarning;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -1279,7 +1282,7 @@ public class OracleStatementImplTest {
       // inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(?); END;")
-        .bind(0, new InOutParameter(1, R2dbcType.NUMERIC))
+        .bind(0, Parameters.inOut(R2dbcType.NUMERIC, 1))
         .execute(),
         result -> {
           awaitNone(result.getRowsUpdated());
@@ -1293,7 +1296,7 @@ public class OracleStatementImplTest {
       // parameter's default value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(:value); END;")
-        .bind("value", new InOutParameter(2, R2dbcType.NUMERIC))
+        .bind("value", Parameters.inOut(R2dbcType.NUMERIC, 2))
         .execute(),
         result ->
           awaitOne(1, result.map(row ->
@@ -1307,7 +1310,7 @@ public class OracleStatementImplTest {
       // parameter's value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(:value); END;")
-        .bind("value", new InOutParameter(3))
+        .bind("value", Parameters.inOut(3))
         .execute(),
         result ->
           awaitNone(result.getRowsUpdated()));
@@ -1320,7 +1323,7 @@ public class OracleStatementImplTest {
       // parameter's value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testOneInOutCallAdd(?); END;")
-        .bind(0, new InOutParameter(4))
+        .bind(0, Parameters.inOut(4))
         .execute(),
         result ->
           awaitOne(3, result.map(row ->
@@ -1374,8 +1377,8 @@ public class OracleStatementImplTest {
       // inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(:value1, :value2); END;")
-        .bind("value1", new InOutParameter(1, R2dbcType.NUMERIC))
-        .bind("value2", new InOutParameter(101, R2dbcType.NUMERIC))
+        .bind("value1", Parameters.inOut(R2dbcType.NUMERIC, 1))
+        .bind("value2", Parameters.inOut(R2dbcType.NUMERIC, 101))
         .execute(),
         result ->
           awaitNone(result.getRowsUpdated()));
@@ -1389,8 +1392,8 @@ public class OracleStatementImplTest {
       // parameter's default value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(?, :value2); END;")
-        .bind(0, new InOutParameter(2, R2dbcType.NUMERIC))
-        .bind("value2", new InOutParameter(102, R2dbcType.NUMERIC))
+        .bind(0, Parameters.inOut(R2dbcType.NUMERIC, 2))
+        .bind("value2", Parameters.inOut(R2dbcType.NUMERIC, 102))
         .execute(),
         result ->
           awaitOne(asList(1, 101), result.map(row ->
@@ -1406,8 +1409,8 @@ public class OracleStatementImplTest {
       // parameter's value to have been inserted by the call.
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(?, ?); END;")
-        .bind(0, new InOutParameter(3))
-        .bind(1, new InOutParameter(103))
+        .bind(0, Parameters.inOut(3))
+        .bind(1, Parameters.inOut(103))
         .execute(),
         result -> awaitNone(result.getRowsUpdated()));
       awaitQuery(asList(asList(3, 103)),
@@ -1422,8 +1425,8 @@ public class OracleStatementImplTest {
       consumeOne(connection.createStatement(
         "BEGIN testMultiInOutCallAdd(" +
           "inout_value2 => :value2, inout_value1 => :value1); END;")
-        .bind("value1", new InOutParameter(4))
-        .bind("value2", new InOutParameter(104))
+        .bind("value1", Parameters.inOut(4))
+        .bind("value2", Parameters.inOut(104))
         .execute(),
         result ->
           awaitOne(asList(3, 103), result.map(row ->
@@ -2238,39 +2241,307 @@ public class OracleStatementImplTest {
     }
   }
 
-  // TODO: Repalce with Parameters.inOut when that's available
-  private static final class InOutParameter
-    implements Parameter, Parameter.In, Parameter.Out {
-    final Type type;
-    final Object value;
+  /**
+   * Verifies behavior for a PL/SQL call having {@code ARRAY} type IN bind
+   */
+  @Test
+  public void testInArrayCall() {
+    Connection connection = awaitOne(sharedConnection());
+    try {
+      awaitExecution(connection.createStatement(
+        "CREATE TYPE TEST_IN_ARRAY AS ARRAY(8) OF NUMBER"));
+      awaitExecution(connection.createStatement(
+        "CREATE TABLE testInArrayCall(id NUMBER, value TEST_IN_ARRAY)"));
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE PROCEDURE testInArrayProcedure (" +
+          " id IN NUMBER," +
+          " inArray IN TEST_IN_ARRAY)" +
+          " IS" +
+          " BEGIN" +
+          " INSERT INTO testInArrayCall VALUES(id, inArray);" +
+          " END;"));
 
-    InOutParameter(Object value) {
-      this(value, new Type.InferredType() {
-        @Override
-        public Class<?> getJavaType() {
-          return value.getClass();
+      class TestRow {
+        Long id;
+        int[] value;
+        TestRow(Long id, int[] value) {
+          this.id = id;
+          this.value = value;
         }
 
         @Override
-        public String getName() {
-          return "Inferred";
+        public boolean equals(Object other) {
+          return other instanceof TestRow
+            && Objects.equals(((TestRow) other).id, id)
+            && Objects.deepEquals(((TestRow)other).value, value);
         }
-      });
-    }
 
-    InOutParameter(Object value, Type type) {
-      this.value = value;
-      this.type = type;
-    }
+        @Override
+        public String toString() {
+          return id + ", " + Arrays.toString(value);
+        }
+      }
 
-    @Override
-    public Type getType() {
-      return type;
-    }
+      TestRow row0 = new TestRow(0L, new int[]{1, 2, 3});
+      OracleR2dbcTypes.ArrayType arrayType =
+        OracleR2dbcTypes.arrayType("TEST_IN_ARRAY");
+      Statement callStatement = connection.createStatement(
+        "BEGIN testInArrayProcedure(:id, :value); END;");
+      awaitExecution(
+        callStatement
+          .bind("id", row0.id)
+          .bind("value", Parameters.in(arrayType, row0.value)));
 
-    @Override
-    public Object getValue() {
-      return value;
+      awaitQuery(
+        List.of(row0),
+        row ->
+          new TestRow(
+            row.get("id", Long.class),
+            row.get("value", int[].class)),
+        connection.createStatement(
+          "SELECT id, value FROM testInArrayCall ORDER BY id"));
+
+      TestRow row1 = new TestRow(1L, new int[]{4, 5, 6});
+      awaitExecution(
+        callStatement
+          .bind("id", row1.id)
+          .bind("value", Parameters.in(arrayType, row1.value)));
+
+      awaitQuery(
+        List.of(row0, row1),
+        row ->
+          new TestRow(
+            row.get("id", Long.class),
+            row.get("value", int[].class)),
+        connection.createStatement(
+          "SELECT id, value FROM testInArrayCall ORDER BY id"));
+    }
+    finally {
+      tryAwaitExecution(connection.createStatement(
+        "DROP TABLE testInArrayCall"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP PROCEDURE testInArrayProcedure"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_IN_ARRAY"));
+      tryAwaitNone(connection.close());
+    }
+  }
+
+  /**
+   * Verifies behavior for a PL/SQL call having {@code ARRAY} type OUT bind
+   */
+  @Test
+  public void testOutArrayCall() {
+    Connection connection = awaitOne(sharedConnection());
+    try {
+      awaitExecution(connection.createStatement(
+        "CREATE TYPE TEST_OUT_ARRAY AS ARRAY(8) OF NUMBER"));
+      awaitExecution(connection.createStatement(
+        "CREATE TABLE testOutArrayCall(id NUMBER, value TEST_OUT_ARRAY)"));
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE PROCEDURE testOutArrayProcedure (" +
+          "   inId IN NUMBER," +
+          "   outArray OUT TEST_OUT_ARRAY)" +
+          " IS" +
+          " BEGIN" +
+          "   SELECT value INTO outArray" +
+          "     FROM testOutArrayCall" +
+          "     WHERE id = inId;" +
+          " EXCEPTION" +
+          "   WHEN NO_DATA_FOUND THEN" +
+          "     outArray := NULL;" +
+          " END;"));
+
+      class TestRow {
+        Long id;
+        Integer[] value;
+        TestRow(Long id, Integer[] value) {
+          this.id = id;
+          this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+          return other instanceof TestRow
+            && Objects.equals(((TestRow) other).id, id)
+            && Objects.deepEquals(((TestRow)other).value, value);
+        }
+
+        @Override
+        public String toString() {
+          return id + ", " + Arrays.toString(value);
+        }
+      }
+
+      OracleR2dbcTypes.ArrayType arrayType =
+        OracleR2dbcTypes.arrayType("TEST_OUT_ARRAY");
+      Statement callStatement = connection.createStatement(
+        "BEGIN testOutArrayProcedure(:id, :value); END;");
+
+      // Expect a NULL out parameter before any rows have been inserted
+      awaitQuery(
+        List.of(Optional.empty()),
+        outParameters -> {
+          assertNull(outParameters.get("value"));
+          assertNull(outParameters.get("value", int[].class));
+          assertNull(outParameters.get("value", Integer[].class));
+          return Optional.empty();
+        },
+        callStatement
+          .bind("id", -1)
+          .bind("value", Parameters.out(arrayType)));
+
+      // Insert a row and expect an out parameter with the value
+      TestRow row0 = new TestRow(0L, new Integer[]{1, 2, 3});
+      awaitUpdate(1, connection.createStatement(
+          "INSERT INTO testOutArrayCall VALUES (:id, :value)")
+        .bind("id", row0.id)
+        .bind("value", Parameters.in(arrayType, row0.value)));
+      awaitQuery(
+        List.of(row0),
+        outParameters ->
+          new TestRow(row0.id, outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row0.id)
+          .bind("value", Parameters.out(arrayType)));
+
+      // Insert another row and expect an out parameter with the value
+      TestRow row1 = new TestRow(1L, new Integer[]{4, 5, 6});
+      awaitUpdate(1, connection.createStatement(
+          "INSERT INTO testOutArrayCall VALUES (:id, :value)")
+        .bind("id", row1.id)
+        .bind("value", Parameters.in(arrayType, row1.value)));
+      awaitQuery(
+        List.of(row1),
+        outParameters ->
+          new TestRow(row1.id, outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row1.id)
+          .bind("value", Parameters.out(arrayType)));
+    }
+    finally {
+      tryAwaitExecution(connection.createStatement(
+        "DROP TABLE testOutArrayCall"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP PROCEDURE testOutArrayProcedure"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_OUT_ARRAY"));
+      tryAwaitNone(connection.close());
+    }
+  }
+
+  /**
+   * Verifies behavior for a PL/SQL call having {@code ARRAY} type OUT bind
+   */
+  @Test
+  public void testInOutArrayCall() {
+    Connection connection = awaitOne(sharedConnection());
+    try {
+      awaitExecution(connection.createStatement(
+        "CREATE TYPE TEST_IN_OUT_ARRAY AS ARRAY(8) OF NUMBER"));
+      awaitExecution(connection.createStatement(
+        "CREATE TABLE testInOutArrayCall(id NUMBER, value TEST_IN_OUT_ARRAY)"));
+      awaitExecution(connection.createStatement(
+        "CREATE OR REPLACE PROCEDURE testInOutArrayProcedure (" +
+          "   inId IN NUMBER," +
+          "   inOutArray IN OUT TEST_IN_OUT_ARRAY)" +
+          " IS" +
+          " newValue TEST_IN_OUT_ARRAY;" +
+          " BEGIN" +
+          "" +
+          " newValue := TEST_IN_OUT_ARRAY();" +
+          " newValue.extend(inOutArray.count);" +
+          " FOR i IN 1 .. inOutArray.count LOOP" +
+          "   newValue(i) := inOutArray(i);" +
+          " END LOOP;" +
+          "" +
+          " BEGIN" +
+          "   SELECT value INTO inOutArray" +
+          "     FROM testInOutArrayCall" +
+          "     WHERE id = inId;" +
+          "   DELETE FROM testInOutArrayCall WHERE id = inId;" +
+          "   EXCEPTION" +
+          "     WHEN NO_DATA_FOUND THEN" +
+          "       inOutArray := NULL;" +
+          " END;" +
+          "" +
+          " INSERT INTO testInOutArrayCall VALUES (inId, newValue);" +
+          "" +
+          " END;"));
+
+      class TestRow {
+        Long id;
+        Integer[] value;
+        TestRow(Long id, Integer[] value) {
+          this.id = id;
+          this.value = value;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+          return other instanceof TestRow
+            && Objects.equals(((TestRow) other).id, id)
+            && Objects.deepEquals(((TestRow)other).value, value);
+        }
+
+        @Override
+        public String toString() {
+          return id + ", " + Arrays.toString(value);
+        }
+      }
+
+      OracleR2dbcTypes.ArrayType arrayType =
+        OracleR2dbcTypes.arrayType("TEST_IN_OUT_ARRAY");
+      Statement callStatement = connection.createStatement(
+        "BEGIN testInOutArrayProcedure(:id, :value); END;");
+
+      // Expect a NULL out parameter the first time a row is inserted
+      TestRow row = new TestRow(0L, new Integer[]{1, 2, 3});
+      awaitQuery(
+        List.of(Optional.empty()),
+        outParameters -> {
+          assertNull(outParameters.get("value"));
+          assertNull(outParameters.get("value", int[].class));
+          assertNull(outParameters.get("value", Integer[].class));
+          return Optional.empty();
+        },
+        callStatement
+          .bind("id", row.id)
+          .bind("value", Parameters.inOut(arrayType, row.value)));
+
+      // Update the row and expect an out parameter with the previous value
+      TestRow row1 = new TestRow(row.id, new Integer[]{4, 5, 6});
+      awaitQuery(
+        List.of(row),
+        outParameters ->
+          new TestRow(
+            row.id,
+            outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row.id)
+          .bind("value", Parameters.inOut(arrayType, row1.value)));
+
+      // Update the row again and expect an out parameter with the previous
+      // value
+      TestRow row2 = new TestRow(row.id, new Integer[]{7, 8, 9});
+      awaitQuery(
+        List.of(row1),
+        outParameters ->
+          new TestRow(
+            row.id,
+            outParameters.get("value", Integer[].class)),
+        callStatement
+          .bind("id", row.id)
+          .bind("value", Parameters.inOut(arrayType, row2.value)));
+    }
+    finally {
+      tryAwaitExecution(connection.createStatement(
+        "DROP TABLE testInOutArrayCall"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP PROCEDURE testInOutArrayProcedure"));
+      tryAwaitExecution(connection.createStatement(
+        "DROP TYPE TEST_IN_OUT_ARRAY"));
+      tryAwaitNone(connection.close());
     }
   }
 

--- a/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
+++ b/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
@@ -1919,14 +1919,37 @@ public class TypeMappingTest {
         actual = object.get(i, expectedClass);
       }
 
-
       String message = "Mismatch at attribute index " + i;
 
-      if (expected instanceof Object[] && actual instanceof Object[])
+      if (expected instanceof OracleR2dbcObject
+        && actual instanceof OracleR2dbcObject) {
+        // Need to compare default mappings as OracleR2dbcObject does not
+        // implement equals.
+        assertArrayEquals(
+          toArray((OracleR2dbcObject) expected),
+          toArray((OracleR2dbcObject) actual),
+          message);
+      }
+      else if (expected instanceof Object[] && actual instanceof Object[])
         assertArrayEquals((Object[]) expected, (Object[]) actual, message);
       else
         assertEquals(expected, actual, message);
     }
+  }
+
+  /** Converts an OBJECT to an Object[] of each attribute's default Java type */
+  private static Object[] toArray(OracleR2dbcObject object) {
+    Object[] array = new Object[
+      object.getMetadata().getAttributeMetadatas().size()];
+
+    for (int i = 0; i < array.length; i++) {
+      array[i] = object.get(i);
+
+      if (array[i] instanceof OracleR2dbcObject)
+        array[i] = toArray((OracleR2dbcObject) array[i]);
+    }
+
+    return array;
   }
 
   // TODO: More tests for JDBC 4.3 mappings like BigInteger to BIGINT,

--- a/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
+++ b/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
@@ -653,7 +653,7 @@ public class TypeMappingTest {
         i -> {
           long[] moreLongs = new long[longs.length];
           for (int j = 0; j < longs.length; j++)
-            moreLongs[j] = (long)(longs[j] + i);
+            moreLongs[j] = longs[j] + i;
           return moreLongs;
         },
         false,

--- a/src/test/java/oracle/r2dbc/test/DatabaseConfig.java
+++ b/src/test/java/oracle/r2dbc/test/DatabaseConfig.java
@@ -21,7 +21,6 @@
 
 package oracle.r2dbc.test;
 
-import io.r2dbc.spi.ColumnMetadata;
 import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
 import io.r2dbc.spi.ConnectionFactory;
@@ -30,7 +29,6 @@ import io.r2dbc.spi.Option;
 import oracle.jdbc.OracleConnection;
 import oracle.r2dbc.util.SharedConnectionFactory;
 import org.reactivestreams.Publisher;
-import reactor.core.publisher.Flux;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -38,7 +36,6 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.Duration;
 import java.util.Properties;
-import java.util.stream.Collectors;
 
 /**
  * Stores configuration used by integration tests that connect to a database.
@@ -189,28 +186,6 @@ public final class DatabaseConfig {
     catch (SQLException sqlException) {
       throw new AssertionError(sqlException);
     }
-  }
-
-  /**
-   * Queries the {@code user_errors} data dictionary view and prints all rows.
-   * When writing new tests that declare a PL/SQL procedure or function,
-   * "ORA-17110: executed completed with a warning" results if the PL/SQL has
-   * a syntax error. The error details will be printed by calling this method.
-   */
-  public static void showErrors(Connection connection) {
-      Flux.from(connection.createStatement(
-        "SELECT * FROM user_errors ORDER BY sequence")
-        .execute())
-        .flatMap(result ->
-          result.map((row, metadata) ->
-            metadata.getColumnMetadatas()
-              .stream()
-              .map(ColumnMetadata::getName)
-              .map(name -> name + ": " + row.get(name))
-              .collect(Collectors.joining("\n"))))
-      .toStream()
-      .map(errorText -> "\n" + errorText)
-      .forEach(System.err::println);
   }
 
   /**

--- a/src/test/java/oracle/r2dbc/test/TestUtils.java
+++ b/src/test/java/oracle/r2dbc/test/TestUtils.java
@@ -1,0 +1,70 @@
+package oracle.r2dbc.test;
+
+import io.r2dbc.spi.ColumnMetadata;
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.Parameters;
+import io.r2dbc.spi.Statement;
+import oracle.r2dbc.OracleR2dbcObject;
+import oracle.r2dbc.OracleR2dbcTypes;
+import reactor.core.publisher.Flux;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+import static oracle.r2dbc.util.Awaits.awaitOne;
+
+public class TestUtils {
+
+  /**
+   * Queries the {@code user_errors} data dictionary view and prints all rows.
+   * When writing new tests that declare a PL/SQL procedure or function,
+   * "ORA-17110: executed completed with a warning" results if the PL/SQL has
+   * a syntax error. The error details will be printed by calling this method.
+   */
+  public static void showErrors(Connection connection) {
+      Flux.from(connection.createStatement(
+        "SELECT * FROM user_errors ORDER BY sequence")
+        .execute())
+        .flatMap(result ->
+          result.map((row, metadata) ->
+            metadata.getColumnMetadatas()
+              .stream()
+              .map(ColumnMetadata::getName)
+              .map(name -> name + ": " + row.get(name))
+              .collect(Collectors.joining("\n"))))
+      .toStream()
+      .map(errorText -> "\n" + errorText)
+      .forEach(System.err::println);
+  }
+
+  /**
+   * Constructs an OBJECT of a given {@code objectType} with the given attribute
+   * {@code attributeValues}.
+   */
+  public static OracleR2dbcObject constructObject(
+    Connection connection, OracleR2dbcTypes.ObjectType objectType,
+    Object... attributeValues) {
+
+    Statement constructor = connection.createStatement(format(
+      "{? = call %s(%s)}",
+      objectType.getName(),
+      Arrays.stream(attributeValues)
+        .map(value ->
+          // Bind the NULL literal, as SQL type of the bind value can not be
+          // inferred from a null value
+          value == null ? "NULL" : "?")
+        .collect(Collectors.joining(","))));
+
+    constructor.bind(0, Parameters.out(objectType));
+
+    for (int i = 0; i < attributeValues.length; i++) {
+      if (attributeValues[i] != null)
+        constructor.bind(i + 1, attributeValues[i]);
+    }
+
+    return awaitOne(Flux.from(constructor.execute())
+      .flatMap(result ->
+        result.map(row -> row.get(0, OracleR2dbcObject.class))));
+  }
+}


### PR DESCRIPTION
This branch adds support for OBJECT types of Oracle Database. This branch subsumes earlier work from #101. Much of the code from that branch is duplicated in this branch.

New interfaces are added to the oracle.r2dbc package, which is exported to user code:
- `OracleR2dbcTypes.ObjectType` : Extends the `io.r2dbc.spi.Type` interface. Represents a user defined OBJECT type. This is used to create `io.r2dbc.spi.Parameter` bind values.
- `OracleR2dbcObject` : Implements `io.r2dbc.spi.Readable` to access OBJECT attribute values. This is Oracle R2DBC's equivalent to JDBC's java.sql.Struct interface.
- `OracleR2dbcObjectMetadata` : A collection of `io.r2dbc.spi.ReadableMetadata` for OBJECT attributes. This Oracle R2DBC's equivalent to Oracle JDBC's oracle.jdbc.StructMetadata.

For general usage examples, please see the added section in the README.md file.