### PR TITLE
Dependencies Update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <java.version>11</java.version>
     <ojdbc.version>21.7.0.0</ojdbc.version>
     <r2dbc.version>1.0.0.RELEASE</r2dbc.version>
-    <reactor.version>2020.0.23</reactor.version>
+    <reactor.version>3.5.0</reactor.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <junit.version>5.9.1</junit.version>
     <spring-jdbc.version>5.3.19</spring-jdbc.version>
@@ -214,6 +214,7 @@
   </build>
 
 
+  <!--
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -225,6 +226,7 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  -->
 
   <dependencies>
     <!-- Oracle R2DBC Driver Dependencies -->
@@ -241,6 +243,7 @@
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-core</artifactId>
+      <version>${reactor.version}</version>
     </dependency>
     <dependency>
       <groupId>org.reactivestreams</groupId>
@@ -273,11 +276,13 @@
       <version>${spring-jdbc.version}</version>
       <scope>test</scope>
     </dependency>
+    <!---
     <dependency>
       <groupId>io.projectreactor</groupId>
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>
     </dependency>
+    -->
 
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -86,18 +86,10 @@
             <arg>-Xlint:-options</arg>
             <arg>-Xlint:-processing</arg>
             <arg>-Xlint:-serial</arg>
+            <!-- LDAP URL tests require the java.naming module -->
+            <testCompilerArgument>--add-modules</testCompilerArgument>
+            <testCompilerArgument>java.naming</testCompilerArgument>
           </compilerArgs>
-          <!-- LDAP URL tests require the java.naming module -->
-          <!-- Maven seems to ignore the forceJavacCompilerUse.
-            This results in an error when passing the addModules option to
-            the javax.tools API. For this reason, Oracle R2DBC's module-info is
-            declaring a depency on the java.naming module.
-            TODO: Figure out how to make maven compile tests correctly, and 
-            remove the java.naming depenency from Oracle R2DBC.
-          <fork>true</fork>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
-          <testCompilerArgument>- -add-modules java.naming</testCompilerArgument>
-          -->
           <showWarnings>true</showWarnings>
           <release>${java.version}</release>
         </configuration>
@@ -166,6 +158,8 @@
             <include>**/*Test.java</include>
             <include>**/*TestKit.java</include>
           </includes>
+          <!-- LDAP URL tests require the java.naming module -->
+          <argLine>--add-reads com.oracle.database.r2dbc=java.naming</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -226,20 +220,6 @@
   </build>
 
 
-  <!--
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.projectreactor</groupId>
-        <artifactId>reactor-bom</artifactId>
-        <version>${reactor.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-  -->
-
   <dependencies>
     <!-- Oracle R2DBC Driver Dependencies -->
     <dependency>
@@ -288,13 +268,6 @@
       <version>${spring-jdbc.version}</version>
       <scope>test</scope>
     </dependency>
-    <!---
-    <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-test</artifactId>
-      <scope>test</scope>
-    </dependency>
-    -->
   </dependencies>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,12 @@
 
   <properties>
     <java.version>11</java.version>
-    <ojdbc.version>21.5.0.0</ojdbc.version>
+    <ojdbc.version>21.7.0.0</ojdbc.version>
     <r2dbc.version>1.0.0.RELEASE</r2dbc.version>
-    <reactor.version>2020.0.19</reactor.version>
+    <reactor.version>2020.0.23</reactor.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
-    <junit.version>5.8.2</junit.version>
-    <spring-jdbc.version>5.2.6.RELEASE</spring-jdbc.version>
+    <junit.version>5.9.1</junit.version>
+    <spring-jdbc.version>5.3.19</spring-jdbc.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -30,7 +30,6 @@ module com.oracle.database.r2dbc {
     with oracle.r2dbc.impl.OracleConnectionFactoryProviderImpl;
 
   requires java.sql;
-  requires java.naming;
   requires com.oracle.database.jdbc;
   requires reactor.core;
   requires transitive org.reactivestreams;


### PR DESCRIPTION
This branch updates the driver's dependencies to their latest versions:
Oracle JDBC 21.7.0.0 (Previously was 21.5.0.0)
Project Reactor 3.5 (Previously was 3.4.18)

Test dependencies are also updated:
JUnit 5.9.1 (Previously was 5.8.2)
Spring JDBC 5.3.19 (Previously was 5.2.6)

Additional clean up:
Removed dependency on java.naming in module-info.java. This had only been added as a temporarily workaround until figuring out how to configure maven correctly.
Removed dependency on reactor-test. It seems that test code had once used this, but no longer does.
