### PR TITLE
Allow Oracle Net Encryption and Checksum Properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,10 @@ supported by Oracle R2DBC:
     - Setting this option to "false" may resolve "ORA-01882: timezone region not 
       found". The ORA-01882 error happens when Oracle Database doesn't recognize 
       the name returned by `java.util.TimeZone.getDefault().getId()`.
+  - [oracle.net.encryption_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_LEVEL)
+  - [oracle.net.encryption_types_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_TYPES)
+  - [oracle.net.crypto_checksum_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_LEVEL)
+  - [oracle.net.crypto_checksum_types_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_TYPES)
 
 ### Thread Safety and Parallel Execution
 Oracle R2DBC's `ConnectionFactory` and `ConnectionFactoryProvider` are the only 

--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -344,6 +344,30 @@ public final class OracleR2dbcOptions {
    */
   public static final Option<CharSequence> LDAP_CONTEXT_PROTOCOL;
 
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_LEVEL}
+   */
+  public static final Option<CharSequence> NET_CHECKSUM_LEVEL;
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_TYPES}
+   */
+  public static final Option<CharSequence> NET_CHECKSUM_TYPES;
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_LEVEL}
+   */
+  public static final Option<CharSequence> NET_ENCRYPTION_LEVEL;
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_TYPES}
+   */
+  public static final Option<CharSequence> NET_ENCRYPTION_TYPES;
+
 
   /** The unmodifiable set of all extended options */
   private static final Set<Option<?>> OPTIONS = Set.of(
@@ -442,7 +466,15 @@ public final class OracleR2dbcOptions {
     LDAP_TRUSTMANAGER_FACTORY_ALGORITHM = Option.valueOf(
       OracleConnection.CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTMANAGER_FACTORY_ALGORITHM),
     LDAP_CONTEXT_PROTOCOL = Option.valueOf(
-      OracleConnection.CONNECTION_PROPERTY_THIN_LDAP_SSL_CONTEXT_PROTOCOL)
+      OracleConnection.CONNECTION_PROPERTY_THIN_LDAP_SSL_CONTEXT_PROTOCOL),
+    NET_CHECKSUM_LEVEL = Option.valueOf(
+      OracleConnection.CONNECTION_PROPERTY_THIN_NET_CHECKSUM_LEVEL),
+    NET_CHECKSUM_TYPES = Option.valueOf(
+      OracleConnection.CONNECTION_PROPERTY_THIN_NET_CHECKSUM_TYPES),
+    NET_ENCRYPTION_LEVEL = Option.valueOf(
+      OracleConnection.CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_LEVEL),
+    NET_ENCRYPTION_TYPES = Option.valueOf(
+      OracleConnection.CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_TYPES)
   );
 
   /**


### PR DESCRIPTION
allows the following properties to be passed to the JDBC connection

- oracle.net.encryption_client
- oracle.net.encryption_types_client
- oracle.net.crypto_checksum_client
- oracle.net.crypto_checksum_types_client
