### PR TITLE
Fixing JavaDocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,7 +697,7 @@ Publisher<Result> objectOutBindExample(Connection connection) {
 `oracle.r2dbc.OracleR2dbcObject`. The `OracleR2dbcObject` interface is a subtype
 of `io.r2dbc.spi.Readable`. Attribute values may be accessed using the standard
 `get` methods of `Readable`. The `get` methods of `OracleR2dbcObject` support
-alll SQL to Java type mappings defined by the
+all SQL to Java type mappings defined by the
 [R2DBC Specification](https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/#datatypes.mapping):
 ```java
 Publisher<Pet> objectMapExample(Result result) {

--- a/src/main/java/oracle/r2dbc/OracleR2dbcObject.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcObject.java
@@ -20,8 +20,59 @@
 */
 package oracle.r2dbc;
 
+/**
+ * <p>
+ * A {@link io.r2dbc.spi.Readable} that represents an instance of a user 
+ * defined OBJECT type.
+ * </p><p>
+ * An OBJECT returned by a {@link io.r2dbc.spi.Result} may be mapped to an
+ * {@code OracleR2dbcObject}:
+ * <pre>{@code
+ * Publisher<Pet> objectMapExample(Result result) {
+ *   return result.map(row -> {
+ *
+ *     OracleR2dbcObject oracleObject = row.get(0, OracleR2dbcObject.class); 
+ *
+ *     return new Pet(
+ *       oracleObject.get("name", String.class),
+ *       oracleObject.get("species", String.class),
+ *       oracleObject.get("weight", Float.class),
+ *       oracleObject.get("birthday", LocalDate.class));
+ *   });
+ * }
+ *
+ * }</pre>
+ * As seen in the example above, the values of an OBJECT's attributes may be 
+ * accessed by name with {@link #get(String)} or {@link #get(String, Class)}.
+ * Alternatively, attribute values may be accessed by index with {@link #get(int)} or
+ * {@link #get(int, Class)}. The {@code get} methods support all standard
+ * SQL-to-Java type mappings defined by the
+ * <a href="https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/#datatypes.mapping">
+ * R2DBC Specification.
+ * </a>
+ * <p>
+ * Instances of {@code OracleR2dbcObject} may be set as a bind value when 
+ * passed to {@link io.r2dbc.spi.Statement#bind(int, Object)} or
+ * {@link io.r2dbc.spi.Statement#bind(String, Object)}:
+ * <pre>{@code
+ * Publisher<Result> objectBindExample(
+ *   OracleR2dbcObject oracleObject, Connection connection) {
+ *
+ *   Statement statement =
+ *     connection.createStatement("INSERT INTO petTable VALUES (:petObject)");
+ *   
+ *   statement.bind("petObject", oracleObject);
+ * 
+ *   return statement.execute();
+ * }
+ * }</pre>
+ */
 public interface OracleR2dbcObject extends io.r2dbc.spi.Readable {
 
+  /**
+   * Returns metadata for the attributes of this OBJECT.
+   * @return The metadata of this OBJECT's attributes. Not null.
+   */
   OracleR2dbcObjectMetadata getMetadata();
 
 }

--- a/src/main/java/oracle/r2dbc/impl/OracleReadableImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReadableImpl.java
@@ -142,6 +142,8 @@ class OracleReadableImpl implements io.r2dbc.spi.Readable {
    * </p>
    * @param jdbcConnection JDBC connection that created the
    *   {@code jdbcReadable}. Not null.
+   * @param dependentCounter Counter that is increased for each dependent
+   * {@code Result} created by the returned {@code Row}
    * @param jdbcReadable Row data from the Oracle JDBC Driver. Not null.
    * @param metadata Meta-data for the specified row. Not null.
    * @param adapter Adapts JDBC calls into reactive streams. Not null.
@@ -164,6 +166,8 @@ class OracleReadableImpl implements io.r2dbc.spi.Readable {
    * </p>
    * @param jdbcConnection JDBC connection that created the
    *   {@code jdbcReadable}. Not null.
+   * @param dependentCounter Counter that is increased for each dependent
+   * {@code Result} created by the returned {@code OutParameters}
    * @param jdbcReadable Row data from the Oracle JDBC Driver. Not null.
    * @param metadata Meta-data for the specified row. Not null.
    * @param adapter Adapts JDBC calls into reactive streams. Not null.

--- a/src/main/java/oracle/r2dbc/impl/ReadablesMetadata.java
+++ b/src/main/java/oracle/r2dbc/impl/ReadablesMetadata.java
@@ -105,6 +105,8 @@ class ReadablesMetadata<T extends ReadableMetadata> {
   /**
    * Creates {@code OracleR2dbcObjectMetadata} that supplies attribute metadata
    * from a JDBC {@code OracleStruct} object.
+   * @param oracleStruct Struct created by Oracle JDBC. Not null.
+   * @return R2DBC metadata for the attributes of the struct. Not null.
    */
   static OracleR2dbcObjectMetadataImpl createAttributeMetadata(
     OracleStruct oracleStruct) {


### PR DESCRIPTION
This branch adds a JavaDoc for OracleR2dbcObject, which was non-existant up to this point. This branch also corrects the JavaDoc of OracleR2dbcTypes.ObjectType, which was mistakenly copy/pasted from ArrayType. Finally, this branch adds some missing '@param' and '@return' tags to internal JavaDocs.