### PR TITLE
Check for Common FJP Having Zero Threads

### DIFF
--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -56,9 +56,11 @@ public final class OracleR2dbcOptions {
    *   ...
    *   .build();
    * </pre>
-   * If this option is not configured, then Oracle R2DBC will use
-   * {@code ForkJoinPool}'s
-   * {@linkplain ForkJoinPool#commonPool() common pool} by default.
+   * If this option is not configured, then Oracle R2DBC will
+   * use the {@linkplain ForkJoinPool#commonPool() common ForkJoinPool} by
+   * default. However, if the common {@code ForkJoinPool} has a maximum pool
+   * size that is potentially zero, then a single-threaded {@code Executor} will
+   * be used by default.
    */
   public static final Option<Executor> EXECUTOR;
 

--- a/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryImpl.java
@@ -108,20 +108,13 @@ final class OracleConnectionFactoryImpl implements ConnectionFactory {
    * configured. It will use the common {@code ForkJoinPool}, unless it has
    * a maximum pool size of 0. See:
    * https://github.com/oracle/oracle-r2dbc/issues/129
-   * </p><p>
-   * As of JDK 11, it appears that ForkJoinPool does not expose a
-   * maximum pool size. {@link ForkJoinPool#getCommonPoolParallelism()} and
-   * {@link ForkJoinPool#getParallelism()} will return 1 when the maximum pool
-   * size is 0. For this reason, the conditional below will check for a
-   * parallelism that is greater than 1, rather than 0. It is noted that
-   * {@code CompletableFuture} uses the same logic when initializing its
-   * USE_COMMON_POOL field.
    * </p>
    */
   private static final Executor DEFAULT_EXECUTOR =
-    ForkJoinPool.getCommonPoolParallelism() > 1
-      ? ForkJoinPool.commonPool()
-      : new ForkJoinPool(1);
+    "0".equals(System.getProperty(
+      "java.util.concurrent.ForkJoinPool.common.parallelism"))
+      ? new ForkJoinPool(1)
+      : ForkJoinPool.commonPool();
 
   /** JDBC data source that this factory uses to open connections */
   private final DataSource dataSource;

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -3222,7 +3222,7 @@ public class OracleStatementImplTest {
       // Create many statements and execute them in parallel.
       @SuppressWarnings({"unchecked","rawtypes"})
       Publisher<Long>[] publishers =
-        new Publisher[Runtime.getRuntime().availableProcessors() * 4];
+        new Publisher[Runtime.getRuntime().availableProcessors() * 2];
 
       for (int i = 0; i < publishers.length; i++) {
 


### PR DESCRIPTION
This branch addresses the case where the common ForkJoinPool (FJP) has zero threads. This can occur with `-Djava.util.concurrent.ForkJoinPool.common.parallelism=0`, or in certain Kubernetes environments on certain versions of the JDK. 
When this condition occurs, the result is brutal for our users. The system will simply hang without reporting any error. A jstack dump won't show any threads blocked either. The user will have no indication about it is causing the issue and how to fix it.
The fix will have Oracle R2DBC fallback to a single threaded ForkJoinPool if the common pool _potentially_ has zero threads. Unfortunately, there is no simple way to distinguish between common FJP that has 1 thread or 0 threads. The `getParallelism` and `getCommonPoolParallelism` methods both return 1 when the FJP has 0 threads. They also return 1 when the FJP has 1 thread. So the fix will fall back to a single threaded FJP in either case. 

Revised Fix:
Oracle R2DBC will only check for common.parallelism=0. This is the only valid way to have zero threads in the common pool.
Oracle R2DBC will not check for getCommonPoolParallelism()==1. That fix is only valuable when the JDK has a defect. The fix detract value for users who aren't using a defective JDK, as it unnecessarily allocates an additional thread.