### PR TITLE
Fix "Operator has been terminated"

### DIFF
--- a/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
@@ -925,14 +925,11 @@ abstract class OracleResultImpl implements Result {
     protected final <T extends Segment, U> Publisher<U> mapSegments(
       Class<T> segmentType, Function<? super T, U> segmentMapper) {
 
-      @SuppressWarnings("unchecked")
-      Publisher<U> removeDependent = (Publisher<U>) dependentCounter.decrement();
+      Publisher<Void> removeDependent = dependentCounter.decrement();
 
-      return Flux.concatDelayError(
+      return Publishers.concatTerminal(
         mapDependentSegments(segmentType, segmentMapper),
-        removeDependent)
-        .doOnCancel(() ->
-          Mono.from(removeDependent).subscribe());
+        removeDependent);
     }
 
     /**

--- a/src/main/java/oracle/r2dbc/impl/Publishers.java
+++ b/src/main/java/oracle/r2dbc/impl/Publishers.java
@@ -1,0 +1,78 @@
+/*
+  Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+
+  This software is dual-licensed to you under the Universal Permissive License
+  (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License
+  2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+  either license.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package oracle.r2dbc.impl;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * Factory methods that create a {@code Publisher}. These methods cover special
+ * cases which are not already supported by Project Reactor.
+ */
+class Publishers {
+
+  private Publishers() {}
+
+  /**
+   * A publisher that immediately emits onNext and onComplete to subscribers
+   */
+  private static final Publisher<Object> COMPLETED_PUBLISHER =
+    Mono.just(new Object());
+
+  /**
+   * <p>
+   * Returns a publisher that emits the concatenated signals of a
+   * {@code publisher} and {@code onTerminationPublisher}. If the
+   * {@code onTerminationPublisher} emits an error, it will suppress any error
+   * emitted by the first {@code publisher}. If a subscription to the returned
+   * publisher is cancelled, the {@code onTerminationPublisher} is subscribed to
+   * it can not emit any error through the cancelled subscription.
+   * </p><p>
+   * The returned publisher behaves similarly to: <pre>{@code
+   * Flux.concatDelayError(
+   *   publisher,
+   *   onTerminationPublisher)
+   *   .doOnCancel(onTerminationPublisher::subscribe)
+   * }</pre>
+   * However, the code above can result in:
+   * <pre>
+   *   reactor.core.Exceptions$StaticThrowable: Operator has been terminated
+   * </pre>
+   * This seems to happen when the concatDelayError publisher receives a cancel
+   * from a downstream subscriber after it has already received onComplete from
+   * a upstream publisher.
+   * </p>
+   * @param publisher First publisher which is subscribed to.
+   * @param onTerminationPublisher Publisher which is subscribed to when the
+   * first publisher terminates, or a subcription is cancelled.
+   * @return The concatenated publisher.
+   * @param <T> Type of objects emitted to onNext
+   */
+  static <T> Publisher<T> concatTerminal(
+    Publisher<T> publisher, Publisher<Void> onTerminationPublisher) {
+    return Flux.usingWhen(
+      COMPLETED_PUBLISHER,
+      ignored -> publisher,
+      ignored -> onTerminationPublisher);
+  }
+}

--- a/src/main/java/oracle/r2dbc/impl/Publishers.java
+++ b/src/main/java/oracle/r2dbc/impl/Publishers.java
@@ -46,7 +46,7 @@ class Publishers {
    * {@code onTerminationPublisher} emits an error, it will suppress any error
    * emitted by the first {@code publisher}. If a subscription to the returned
    * publisher is cancelled, the {@code onTerminationPublisher} is subscribed to
-   * it can not emit any error through the cancelled subscription.
+   * but it can not emit any error through the cancelled subscription.
    * </p><p>
    * The returned publisher behaves similarly to: <pre>{@code
    * Flux.concatDelayError(


### PR DESCRIPTION
Fixes #133 

This branch corrects what appears to be unsupported usage of the Project Reactor API. Oracle R2DBC was combining Flux.concatDelayError with Flux.doOnCancel to trigger resource clean up upon termination with onComplete, onError, or cancel. 

My understanding of Project Reactor is this:
If the (concatDelayError + doOnCancel) publisher receives onComplete, it stores a reference to reactor.core.Exceptions.TERMINATED. If this publisher then receives a cancel, it sees the reference to TERMINATED and reports it as a dropped error. The message of TERMINATED is "Operator has been terminated", which will appear in stderr or in log messages.

The fix is to simply to use the Flux.usingWhen method to trigger resource clean up. I believe this is the intended usage of the Project Reactor API, so it should serve us better than what we had before.