### PR TITLE
Option Values from Supplier and Publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,15 +242,15 @@ thread safe `get()` method, as multiple threads may invoke
 `ConnectionFactory.create()` concurrently. If the `Supplier` returns `null`,
 then no value is configured for the `Option`. If the `Supplier` throws a
 `RuntimeException`, then it is set as the initial cause of an
-`R2dbcException` emitted by `create()` `Publisher`.
+`R2dbcException` emitted by the `create()` `Publisher`.
 
 If an `Option` is configured as a `Publisher`, then Oracle R2DBC requests the 
 value of that `Option` by subscribing to the `Publisher` and signalling demand.
 The first value emitted to `onNext` will be used as the value of the `Option`.
 If the `Publisher` emits `onComplete` before `onNext`, then no value is 
 configured for the `Option`. If the `Publisher` emits a `Throwable` to `onError`
-before `onNext`, it is set as the initial cause of an `R2dbcException` emitted 
-by `create()` `Publisher`.
+before `onNext`, then it is set as the initial cause of an `R2dbcException` 
+emitted by the `create()` `Publisher`.
 
 A small subset of `Options` can not be configured with a `Supplier` or 
 `Publisher`:

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ allows connections to be configured with values that change over time, such as a
 password that gets periodically rotated.
 
 If a `Supplier` provides the value of an `Option`, then Oracle R2DBC requests 
-the value by invoking `Supplier.get()` method. If the `get()` returns `null`,
+the value by invoking `Supplier.get()`. If `get()` returns `null`,
 then no value is configured for the `Option`. If `get()` throws a
 `RuntimeException`, then it is set as the initial cause of an
 `R2dbcException` emitted by the `create()` `Publisher`. If concurrent
@@ -292,6 +292,15 @@ set of options:
 
 Providing values for these options would not be interoperable with
 `io.r2dbc.spi.ConnectionFactories` and `r2dbc-pool`.
+
+Normally, Oracle R2DBC will not retain references to `Option` values after
+`ConnectionFactories.create(ConnectionFactoryOptions)` returns. However, if
+the value of at least one `Option` is provided by a `Supplier` or `Publisher`, 
+then Oracle R2DBC will retain a reference to all `Option` values until the 
+`ConnectionFactory.create()` `Publisher` emits a `Connection` or error. This is
+important to keep in mind when `Option` values may be mutated. In particular,
+a password may only be cleared from memory after the `create()` `Publisher` 
+emits a `Connection` or error.
 
 #### Configuring an Oracle Net Descriptor
 The `oracle.r2dbc.OracleR2dbcOptions.DESCRIPTOR` option may be used to configure

--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -22,10 +22,12 @@ package oracle.r2dbc;
 
 import io.r2dbc.spi.Option;
 import oracle.jdbc.OracleConnection;
+import org.reactivestreams.Publisher;
 
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ForkJoinPool;
+import java.util.function.Supplier;
 
 /**
  * Extended {@link Option}s supported by the Oracle R2DBC Driver.
@@ -486,6 +488,68 @@ public final class OracleR2dbcOptions {
    */
   public static Set<Option<?>> options() {
     return OPTIONS;
+  }
+
+  /**
+   * <p>
+   * Casts an <code>Option&lt;T&gt;</code> to
+   * <code>Option&lt;Supplier&lt;T&gt;&gt;</code>. For instance, if an
+   * <code>Option&lt;CharSequence&gt;</code> is passed to this method, it is
+   * returned as an
+   * <code>Option&lt;Supplier&lt;CharSequence&gt;&gt;</code>.
+   * </p><p>
+   * This method can used when configuring an <code>Option</code> with values
+   * from a <code>Supplier</code>:
+   * <pre>{@code
+   * void configurePassword(ConnectionFactoryOptions.Builder optionsBuilder) {
+   *   optionsBuilder.option(supplied(PASSWORD), () -> getPassword());
+   * }
+   *
+   * CharSequence getPassword() {
+   *   // ... return a database password ...
+   * }
+   * }</pre>
+   * </p><p>
+   * It is not strictly necessary to use this method when configuring an
+   * <code>Option</code> with a value from a <code>Supplier</code>. This method
+   * is offered for code readability and convenience.
+   * </p>
+   */
+  public static <T> Option<Supplier<T>> supplied(Option<T> option) {
+    @SuppressWarnings("unchecked")
+    Option<Supplier<T>> supplierOption = (Option<Supplier<T>>)option;
+    return supplierOption;
+  }
+
+  /**
+   * <p>
+   * Casts an <code>Option&lt;T&gt;</code> to
+   * <code>Option&lt;Publisher&lt;T&gt;&gt;</code>. For instance, if an
+   * <code>Option&lt;CharSequence&gt;</code> is passed to this method, it
+   * is returned as an
+   * <code>Option&lt;Publisher&lt;CharSequence&gt;&gt;</code>.
+   * </p><p>
+   * This method can used when configuring an <code>Option</code> with values
+   * from a <code>Publisher</code>:
+   * <pre>{@code
+   * void configurePassword(ConnectionFactoryOptions.Builder optionsBuilder) {
+   *   optionsBuilder.option(published(PASSWORD), getPasswordPublisher());
+   * }
+   *
+   * Publisher<CharSequence> getPasswordPublisher() {
+   *   // ... publish a database password ...
+   * }
+   * }</pre>
+   * </p><p>
+   * It is not strictly necessary to use this method when configuring an
+   * <code>Option</code> with a value from a <code>Publisher</code>. This method
+   * is offered for code readability and convenience.
+   * </p>
+   */
+  public static <T> Option<Publisher<T>> published(Option<T> option) {
+    @SuppressWarnings("unchecked")
+    Option<Publisher<T>> publisherOption = (Option<Publisher<T>>)option;
+    return publisherOption;
   }
 
 }

--- a/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryImpl.java
@@ -265,6 +265,6 @@ final class OracleConnectionFactoryImpl implements ConnectionFactory {
    */
   @Override
   public ConnectionFactoryMetadata getMetadata() {
-    return () -> "Oracle Database";
+    return OracleConnectionFactoryMetadataImpl.INSTANCE;
   }
 }

--- a/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryMetadataImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryMetadataImpl.java
@@ -1,0 +1,43 @@
+/*
+  Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+
+  This software is dual-licensed to you under the Universal Permissive License
+  (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License
+  2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+  either license.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package oracle.r2dbc.impl;
+
+import io.r2dbc.spi.ConnectionFactoryMetadata;
+
+/**
+ * Implementation of {@code ConnectionFactoryMetaData} which names
+ * "Oracle Database" as the database product that a
+ * {@link io.r2dbc.spi.ConnectionFactory} connects to.
+ */
+final class OracleConnectionFactoryMetadataImpl
+  implements ConnectionFactoryMetadata {
+
+  static final OracleConnectionFactoryMetadataImpl INSTANCE =
+    new OracleConnectionFactoryMetadataImpl();
+
+  private OracleConnectionFactoryMetadataImpl() {}
+
+  @Override
+  public String getName() {
+    return "Oracle Database";
+  }
+}

--- a/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryProviderImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleConnectionFactoryProviderImpl.java
@@ -96,7 +96,11 @@ public final class OracleConnectionFactoryProviderImpl
   public ConnectionFactory create(ConnectionFactoryOptions options) {
     assert supports(options) : "Options are not supported: " + options;
     requireNonNull(options, "options must not be null.");
-    return new OracleConnectionFactoryImpl(options);
+
+    if (SuppliedOptionConnectionFactory.containsSuppliedValue(options))
+      return new SuppliedOptionConnectionFactory(options);
+    else
+      return new OracleConnectionFactoryImpl(options);
   }
 
   /**

--- a/src/main/java/oracle/r2dbc/impl/SuppliedOptionConnectionFactory.java
+++ b/src/main/java/oracle/r2dbc/impl/SuppliedOptionConnectionFactory.java
@@ -1,0 +1,217 @@
+/*
+  Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+
+  This software is dual-licensed to you under the Universal Permissive License
+  (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License
+  2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+  either license.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package oracle.r2dbc.impl;
+
+import io.r2dbc.spi.Connection;
+import io.r2dbc.spi.ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactoryMetadata;
+import io.r2dbc.spi.ConnectionFactoryOptions;
+import io.r2dbc.spi.Option;
+import oracle.r2dbc.OracleR2dbcOptions;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A connection factory having {@link io.r2dbc.spi.ConnectionFactoryOptions}
+ * with values provided by a {@link Supplier} or {@link Publisher}. Supplied
+ * values are requested when {@link #create()} is called. After all requested
+ * values are supplied, this factory delegates to
+ * {@link OracleConnectionFactoryProviderImpl#create(ConnectionFactoryOptions)},
+ * with {@link ConnectionFactoryOptions} composed of the supplied values.
+ */
+final class SuppliedOptionConnectionFactory implements ConnectionFactory {
+
+  /**
+   * The set of all options recognized by Oracle R2DBC. This set includes
+   * the standard options declared by {@link ConnectionFactoryOptions} and
+   * the extended options declared by {@link OracleR2dbcOptions}.
+   *
+   * TODO: This set only includes standard options defined for version 1.0.0 of
+   *   the SPI. If a future SPI version introduces new options, those must be
+   *   added to this set.
+   */
+  private static final Set<Option<?>> ALL_OPTIONS =
+    Stream.concat(
+        // Standard options:
+        Stream.of(
+          ConnectionFactoryOptions.CONNECT_TIMEOUT,
+          ConnectionFactoryOptions.DATABASE,
+          ConnectionFactoryOptions.DRIVER,
+          ConnectionFactoryOptions.HOST,
+          ConnectionFactoryOptions.LOCK_WAIT_TIMEOUT,
+          ConnectionFactoryOptions.PASSWORD,
+          ConnectionFactoryOptions.PORT,
+          ConnectionFactoryOptions.PROTOCOL,
+          ConnectionFactoryOptions.SSL,
+          ConnectionFactoryOptions.STATEMENT_TIMEOUT,
+          ConnectionFactoryOptions.USER),
+        // Extended options:
+        OracleR2dbcOptions.options().stream())
+      .collect(Collectors.toUnmodifiableSet());
+
+  /**
+   * Publishers which emit the value of an option. The value may come from a
+   * user provided Publisher, from a user provided Supplier, or just a user
+   * provided value. So, all the option values below would get turned into a
+   * Publisher which is added to this set:
+   * <pre>{@code
+   * ConnectionFactoryOptions.builder()
+   *   .option(DRIVER, "oracle")
+   *   .option(supplied(HOST, () -> "database-host")
+   *   .option(published(PORT, Mono.just(1521))
+   * }</pre>
+   */
+  private final Set<Publisher<OptionValue>> optionValuePublishers;
+
+  SuppliedOptionConnectionFactory(ConnectionFactoryOptions options) {
+    optionValuePublishers = ALL_OPTIONS.stream()
+      .map(option -> toOptionValuePublisher(option, options.getValue(option)))
+      .filter(Objects::nonNull)
+      .collect(Collectors.toUnmodifiableSet());
+  }
+
+  @Override
+  public Publisher<? extends Connection> create() {
+    return Flux.merge(optionValuePublishers)
+      .collectList()
+      .map(SuppliedOptionConnectionFactory::toConnectionFactoryOptions)
+      .flatMap(options ->
+        Mono.from(new OracleConnectionFactoryProviderImpl()
+          .create(options)
+          .create()));
+  }
+
+  @Override
+  public ConnectionFactoryMetadata getMetadata() {
+    return OracleConnectionFactoryMetadataImpl.INSTANCE;
+  }
+
+  /**
+   * Converts an {@link Option} and its value to a {@link Publisher} that
+   * emits an {@link OptionValue}. If the <code>value</code> passed to this
+   * method is a Supplier or Publisher, then the Publisher returned by this
+   * method emits an <code>OptionValue</code> with the value supplied by the
+   * Supplier or Publisher. If the <code>value</code> passed to this method is
+   * not a Supplier or Publisher, then the Publisher returned by this method
+   * just emits an <code>OptionValue</code> with the given <code>value</code>.
+   *
+   * @param option An option. Not null.
+   * @param value The value of the option, or null if there is no value, or a
+   * <code>Supplier</code> or <code>Publisher</code> which supplies the value of
+   * the option.
+   * @return A publisher that emits the option and its possibly supplied value,
+   * or this method returns null if the given <code>value</code> is null.
+   */
+  private static Publisher<OptionValue> toOptionValuePublisher(
+    Option<?> option, Object value) {
+    final Publisher<?> valuePublisher;
+
+    if (value == null)
+      return null;
+
+    if (value instanceof Supplier)
+      valuePublisher = Mono.fromSupplier((Supplier<?>)value);
+    else if (value instanceof Publisher)
+      valuePublisher = Mono.from((Publisher<?>)value);
+    else
+      return Mono.just(new OptionValue(option, value));
+
+    return Mono.from(valuePublisher)
+      .map(publishedValue -> new OptionValue(option, publishedValue))
+      .onErrorMap(error -> OracleR2dbcExceptions.newNonTransientException(
+        "Error when requesting a value of " + option
+          + " from a Supplier or Publisher",
+        null, // sql
+        error));
+  }
+
+  /**
+   * Converts a collection of options and values into an instance of
+   * {@link ConnectionFactoryOptions}.
+   *
+   * @param optionValues Iterable options and values. Not null.
+   * @return <code>ConnectionFactoryOptions</code> configured with the given
+   * options and values. Not null.
+   */
+  private static ConnectionFactoryOptions toConnectionFactoryOptions(
+    Iterable<OptionValue> optionValues) {
+
+    ConnectionFactoryOptions.Builder optionsBuilder =
+      ConnectionFactoryOptions.builder();
+
+    optionValues.forEach(optionValue ->
+      optionValue.configure(optionsBuilder));
+
+    return optionsBuilder.build();
+  }
+
+  /**
+   * Checks if the value of an option is supplied by a {@link Supplier} or
+   * {@link Publisher}. This method is used to check if
+   * {@link SuppliedOptionConnectionFactory} should be used to handle any
+   * supplied option values. If this method returns false, then there is no
+   * reason to use this connection factory.
+   *
+   * @param options Options that may a value which is a {@link Supplier} or
+   * {@link Publisher}.
+   * @return true if the value of at least one option is a {@link Supplier} or
+   * {@link Publisher}. Returns false otherwise.
+   */
+  static boolean containsSuppliedValue(
+    ConnectionFactoryOptions options) {
+    return ALL_OPTIONS.stream()
+      .map(options::getValue)
+      .anyMatch(value ->
+        value instanceof Supplier || value instanceof Publisher);
+  }
+
+  /** A record of an {@link Option} and its value */
+  private static final class OptionValue {
+
+    final Option<?> option;
+
+    final Object value;
+
+    OptionValue(Option<?> option, Object value) {
+      this.option = option;
+      this.value = value;
+    }
+
+    /**
+     * @param builder Builder to configure with the {@link #value} of an
+     * {@link #option}. Not null.
+     */
+    void configure(ConnectionFactoryOptions.Builder builder) {
+      @SuppressWarnings("unchecked")
+      Option<Object> option = (Option<Object>)this.option;
+      builder.option(option, value);
+    }
+
+  }
+}

--- a/src/test/java/oracle/r2dbc/impl/OracleConnectionFactoryImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleConnectionFactoryImplTest.java
@@ -179,29 +179,6 @@ public class OracleConnectionFactoryImplTest {
         .getName());
   }
 
-  @Test
-  public void testSupplierOption() {
-    Supplier<String> hostSupplier = DatabaseConfig::host;
-    IntSupplier portSupplier = DatabaseConfig::port;
-    Supplier<String> databaseSupplier = DatabaseConfig::serviceName;
-    Supplier<String> userSupplier = DatabaseConfig::user;
-    Supplier<CharSequence> passwordSupplier = DatabaseConfig::password;
-
-    ConnectionFactoryOptions connectionFactoryOptions =
-      connectionFactoryOptions()
-        .mutate()
-        .option(HOST, HOST.cast(hostSupplier))
-        .option(PORT, PORT.cast(portSupplier))
-        .option(DATABASE, DATABASE.cast(databaseSupplier))
-        .option(USER, USER.cast(userSupplier))
-        .option(PASSWORD, PASSWORD.cast(passwordSupplier))
-        .build();
-
-    Publisher<? extends Connection> connectionPublisher =
-      new OracleConnectionFactoryImpl(connectionFactoryOptions).create();
-    verifyConnectionPublisher(connectionPublisher);
-  }
-
   /** Verifies that a publisher emits connections to multiple subscribers */
   private static void verifyConnectionPublisher(
     Publisher<? extends Connection> connectionPublisher) {

--- a/src/test/java/oracle/r2dbc/impl/OracleConnectionFactoryProviderImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleConnectionFactoryProviderImplTest.java
@@ -21,11 +21,32 @@
 
 package oracle.r2dbc.impl;
 
+import io.r2dbc.spi.Connection;
 import io.r2dbc.spi.ConnectionFactories;
+import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.Option;
+import io.r2dbc.spi.R2dbcException;
+import oracle.r2dbc.test.DatabaseConfig;
 import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static io.r2dbc.spi.ConnectionFactoryOptions.DATABASE;
+import static io.r2dbc.spi.ConnectionFactoryOptions.HOST;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PASSWORD;
+import static io.r2dbc.spi.ConnectionFactoryOptions.PORT;
+import static io.r2dbc.spi.ConnectionFactoryOptions.USER;
+import static oracle.r2dbc.OracleR2dbcOptions.published;
+import static oracle.r2dbc.OracleR2dbcOptions.supplied;
+import static oracle.r2dbc.test.DatabaseConfig.connectionFactoryOptions;
+import static oracle.r2dbc.test.DatabaseConfig.password;
+import static oracle.r2dbc.util.Awaits.awaitError;
+import static oracle.r2dbc.util.Awaits.awaitOne;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -152,4 +173,282 @@ public class OracleConnectionFactoryProviderImplTest {
           .option(unsupported, "expect Oracle R2DBC to ignore this")
           .build()));
   }
+
+  @Test
+  public void testSupplierOption() {
+    Supplier<String> hostSupplier = DatabaseConfig::host;
+    Supplier<Integer> portSupplier = DatabaseConfig::port;
+    Supplier<String> databaseSupplier = DatabaseConfig::serviceName;
+    TestSupplier<String> userSupplier =
+      new TestSupplier<>(DatabaseConfig.user());
+    Supplier<CharSequence> passwordSupplier = DatabaseConfig::password;
+
+    ConnectionFactoryOptions connectionFactoryOptions =
+      connectionFactoryOptions()
+        .mutate()
+        .option(supplied(HOST), hostSupplier)
+        .option(supplied(PORT), portSupplier)
+        .option(supplied(DATABASE), databaseSupplier)
+        .option(supplied(USER), userSupplier)
+        .option(supplied(PASSWORD), passwordSupplier)
+        .build();
+
+    ConnectionFactory connectionFactory =
+      ConnectionFactories.get(connectionFactoryOptions);
+
+    // Round 1: Expect success as all values are supplied
+    verifyConnection(connectionFactory);
+
+    // Round 2: Expect ORA-01017 has an invalid username is supplied
+    userSupplier.value = "not" + DatabaseConfig.user();
+    R2dbcException r2dbcException = verifyConnectionError(connectionFactory);
+    assertEquals(1017, r2dbcException.getErrorCode());
+
+    // Round 3: Expect success as all values are supplied
+    userSupplier.value = DatabaseConfig.user();
+    verifyConnection(connectionFactory);
+
+  }
+
+  @Test
+  public void testSupplierOptionNull() {
+    Supplier<String> hostSupplier = DatabaseConfig::host;
+    Supplier<Integer> portSupplier = DatabaseConfig::port;
+    Supplier<String> databaseSupplier = DatabaseConfig::serviceName;
+    Supplier<String> userSupplier = DatabaseConfig::user;
+    TestSupplier<CharSequence> passwordSupplier = new TestSupplier(password());
+
+    ConnectionFactoryOptions connectionFactoryOptions =
+      connectionFactoryOptions()
+        .mutate()
+        .option(supplied(HOST), hostSupplier)
+        .option(supplied(PORT), portSupplier)
+        .option(supplied(DATABASE), databaseSupplier)
+        .option(supplied(USER), userSupplier)
+        .option(supplied(PASSWORD), passwordSupplier)
+        .option(
+          // Oracle Database doesn't support this option, and Oracle R2DBC
+          // throws an exception if it is set. The supplied null value should
+          // have it not set.
+          supplied(ConnectionFactoryOptions.LOCK_WAIT_TIMEOUT),
+          () -> null)
+        .build();
+
+    ConnectionFactory connectionFactory =
+      ConnectionFactories.get(connectionFactoryOptions);
+
+    // Round 1: Verify success with no lock wait timeout and a password
+    verifyConnection(connectionFactory);
+
+    // Round 2: Verify failure with a null password. The expected error code
+    // may depend on the version of the test database. Expect ORA-01005 with a
+    // 23.3 database.
+    passwordSupplier.value = null;
+    R2dbcException r2dbcException = verifyConnectionError(connectionFactory);
+    assertEquals(1005, r2dbcException.getErrorCode());
+  }
+
+  @Test
+  public void testSupplierOptionError() {
+    class TestException extends RuntimeException { }
+
+    Supplier<String> hostSupplier = DatabaseConfig::host;
+    Supplier<Integer> portSupplier = DatabaseConfig::port;
+    Supplier<String> databaseSupplier = DatabaseConfig::serviceName;
+    TestSupplier<String> userSupplier = new TestSupplier<>(new TestException());
+    Supplier<CharSequence> passwordSupplier = DatabaseConfig::password;
+
+    ConnectionFactoryOptions connectionFactoryOptions =
+      connectionFactoryOptions()
+        .mutate()
+        .option(supplied(HOST), hostSupplier)
+        .option(supplied(PORT), portSupplier)
+        .option(supplied(DATABASE), databaseSupplier)
+        .option(supplied(USER), userSupplier)
+        .option(supplied(PASSWORD), passwordSupplier)
+        .build();
+
+    ConnectionFactory connectionFactory =
+      ConnectionFactories.get(connectionFactoryOptions);
+
+    // Round 1: Expect a failure from the TestSupplier
+    R2dbcException r2dbcException = verifyConnectionError(connectionFactory);
+
+    assertTrue(
+      r2dbcException.getCause() instanceof TestException,
+      "Unexpected cause: " + r2dbcException.getCause());
+
+    // Round 2: Expect success as the TestSupplier no longer throws an error
+    userSupplier.error = null;
+    userSupplier.value = DatabaseConfig.user();
+    verifyConnection(connectionFactory);
+  }
+
+  @Test
+  public void testPublisherOption() {
+    Publisher<String> hostPublisher = Mono.fromSupplier(DatabaseConfig::host);
+    Publisher<Integer> portPublisher = Mono.fromSupplier(DatabaseConfig::port);
+    Publisher<String> databasePublisher = Mono.fromSupplier(DatabaseConfig::serviceName);
+    TestSupplier<String> userPublisher =
+      new TestSupplier<>(DatabaseConfig.user());
+    Publisher<CharSequence> passwordPublisher = Mono.fromSupplier(DatabaseConfig::password);
+
+    ConnectionFactoryOptions connectionFactoryOptions =
+      connectionFactoryOptions()
+        .mutate()
+        .option(published(HOST), hostPublisher)
+        .option(published(PORT), portPublisher)
+        .option(published(DATABASE), databasePublisher)
+        .option(published(USER), Mono.fromSupplier(userPublisher))
+        .option(published(PASSWORD), passwordPublisher)
+        .build();
+
+    ConnectionFactory connectionFactory =
+      ConnectionFactories.get(connectionFactoryOptions);
+
+    // Round 1: Expect success as all values are published
+    verifyConnection(connectionFactory);
+
+    // Round 2: Expect ORA-01017 has an invalid username is published
+    userPublisher.value = "not" + DatabaseConfig.user();
+    R2dbcException r2dbcException = verifyConnectionError(connectionFactory);
+    assertEquals(1017, r2dbcException.getErrorCode());
+
+    // Round 3: Expect success as all values are published
+    userPublisher.value = DatabaseConfig.user();
+    verifyConnection(connectionFactory);
+
+  }
+
+  @Test
+  public void testPublisherOptionNull() {
+    Publisher<String> hostPublisher = Mono.fromSupplier(DatabaseConfig::host);
+    Publisher<Integer> portPublisher = Mono.fromSupplier(DatabaseConfig::port);
+    Publisher<String> databasePublisher = Mono.fromSupplier(DatabaseConfig::serviceName);
+    Publisher<String> userPublisher = Mono.fromSupplier(DatabaseConfig::user);
+    TestSupplier<CharSequence> passwordPublisher = new TestSupplier(password());
+
+    ConnectionFactoryOptions connectionFactoryOptions =
+      connectionFactoryOptions()
+        .mutate()
+        .option(published(HOST), hostPublisher)
+        .option(published(PORT), portPublisher)
+        .option(published(DATABASE), databasePublisher)
+        .option(published(USER), userPublisher)
+        .option(published(PASSWORD), Mono.fromSupplier(passwordPublisher))
+        .option(
+          // Oracle Database doesn't support this option, and Oracle R2DBC
+          // throws an exception if it is set. The published null value should
+          // have it not set.
+          published(ConnectionFactoryOptions.LOCK_WAIT_TIMEOUT),
+          Mono.empty())
+        .build();
+
+    ConnectionFactory connectionFactory =
+      ConnectionFactories.get(connectionFactoryOptions);
+
+    // Round 1: Verify success with no lock wait timeout and a password
+    verifyConnection(connectionFactory);
+
+    // Round 2: Verify failure with a null password. The expected error code
+    // may depend on the version of the test database. Expect ORA-01005 with a
+    // 23.3 database.
+    passwordPublisher.value = null;
+    R2dbcException r2dbcException = verifyConnectionError(connectionFactory);
+    assertEquals(1005, r2dbcException.getErrorCode());
+  }
+
+  @Test
+  public void testPublisherOptionError() {
+    class TestException extends RuntimeException { }
+
+    Publisher<String> hostPublisher = Mono.fromSupplier(DatabaseConfig::host);
+    Publisher<Integer> portPublisher = Mono.fromSupplier(DatabaseConfig::port);
+    Publisher<String> databasePublisher = Mono.fromSupplier(DatabaseConfig::serviceName);
+    TestSupplier<String> userPublisher = new TestSupplier<>(new TestException());
+    Publisher<CharSequence> passwordPublisher = Mono.fromSupplier(DatabaseConfig::password);
+
+    ConnectionFactoryOptions connectionFactoryOptions =
+      connectionFactoryOptions()
+        .mutate()
+        .option(published(HOST), hostPublisher)
+        .option(published(PORT), portPublisher)
+        .option(published(DATABASE), databasePublisher)
+        .option(published(USER), Mono.fromSupplier(userPublisher))
+        .option(published(PASSWORD), passwordPublisher)
+        .build();
+
+    ConnectionFactory connectionFactory =
+      ConnectionFactories.get(connectionFactoryOptions);
+
+    // Round 1: Expect a failure from the TestSupplier
+    R2dbcException r2dbcException = verifyConnectionError(connectionFactory);
+
+    assertTrue(
+      r2dbcException.getCause() instanceof TestException,
+      "Unexpected cause: " + r2dbcException.getCause());
+
+    // Round 2: Expect success as the TestSupplier no longer throws an error
+    userPublisher.error = null;
+    userPublisher.value = DatabaseConfig.user();
+    verifyConnection(connectionFactory);
+  }
+
+  /** Verifies that a connection can be created with the given options */
+  private void verifyConnection(ConnectionFactory connectionFactory) {
+
+    awaitOne(
+      1,
+      Flux.usingWhen(
+        connectionFactory.create(),
+        connection ->
+          Flux.from(
+              connection.createStatement("SELECT 1 FROM sys.dual").execute())
+            .flatMap(result ->
+              result.map(row -> row.get(0, Integer.class))),
+        Connection::close));
+  }
+
+  /**
+   * Verifies that a connection fails to be created with the given options,
+   * and returns the exception.
+   */
+  private R2dbcException verifyConnectionError(
+    ConnectionFactory connectionFactory) {
+
+    return awaitError(
+      R2dbcException.class,
+      Flux.usingWhen(
+        connectionFactory.create(),
+        connection ->
+          Flux.from(
+              connection.createStatement("SELECT 1 FROM sys.dual").execute())
+            .flatMap(result ->
+              result.map(row -> row.get(0, Integer.class))),
+        Connection::close));
+  }
+
+  private static final class TestSupplier<T> implements Supplier<T> {
+
+    T value;
+
+    RuntimeException error;
+
+    TestSupplier(RuntimeException error) {
+      this.error = error;
+    }
+
+    TestSupplier(T value) {
+      this.value = value;
+    }
+
+    @Override
+    public T get() {
+      if (error != null)
+        throw error;
+
+      return value;
+    }
+  }
+
 }

--- a/src/test/java/oracle/r2dbc/util/Awaits.java
+++ b/src/test/java/oracle/r2dbc/util/Awaits.java
@@ -104,9 +104,9 @@ public final class Awaits {
    * @throws Throwable If the publisher emits {@code onError} with a
    * {@code Throwable} that is not an instance of {@code errorType}.
    */
-  public static void awaitError(
-    Class<? extends Throwable> errorType, Publisher<?> errorPublisher) {
-    assertThrows(
+  public static <T extends Throwable> T awaitError(
+    Class<T> errorType, Publisher<?> errorPublisher) {
+    return assertThrows(
       errorType,
       () -> Flux.from(errorPublisher).blockLast(sqlTimeout()),
       "Unexpected signal from Publisher of an error");


### PR DESCRIPTION
This branch allows a java.util.function.Supplier or an org.reactivestreams.Publisher to provide the value of an io.r2dbc.spi.Option. This is useful for values which change over time, such as a password which gets rotated, or an access token which gets refreshed. Users will no longer need to recreate their connection pool in order to update the value of an option. Instead, their Supplier or Publisher can provide updated values for new connections.

With a small number of exceptions, any Option can be configured to have a Supplier or Publisher provide the value. In order to call ConnectionFactoryOptions.Builder.option(Option<T>, T) with T being a Supplier or Publisher, users must cast the generic type of the Option accordingly. For instance, if a user wants to call this method with ConnectionFactoryOptions.PASSWORD and a Supplier, then PASSWORD must be cast from an `Option<CharSequence>` to an `Option<Supplier<CharSequence>>`. New methods which perform these casts are added to the exported API of OracleR2dbcOptions.

Casting the generic type of an Option is safe so long as no other component besides Oracle R2DBC will consume that option's value. Casting is not safe for the DRIVER option, which is consumed as a String by io.r2dbc.ConnectionFactories. Casting is also not safe for the PROTOCOL option, which consumed as a String by r2dbc-pool.

In previous releases, Oracle R2DBC was specified to not retain any reference to any option's value after ConnectionFactories.create(ConnectionFactoryOptions) had returned. This specification does not apply if a Supplier or
Publisher provides the value of at least one Option. In this case, references to all Option values are permanently retained by the ConnectionFactory. This limitation allows the implementation of this feature to remain fairly simple. If this limitation is not acceptable to users, then I will investigate alternative implementations which can resolve it.