### PR TITLE
Support for Pipelining

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Oracle R2DBC is compatible with JDK 11 (or newer), and has the following runtime
 - Project Reactor 3.5.11
 - Oracle JDBC 21.11.0.0 for JDK 11 (ojdbc11.jar)
   - Oracle R2DBC relies on the Oracle JDBC Driver's [Reactive Extensions
-  ](https://docs.oracle.com/en/database/oracle/oracle-database/21/jjdbc/jdbc-reactive-extensions.html#GUID-1C40C43B-3823-4848-8B5A-D2F97A82F79B) APIs.
+  ](https://docs.oracle.com/en/database/oracle/oracle-database/23/jjdbc/jdbc-reactive-extensions.html#GUID-1C40C43B-3823-4848-8B5A-D2F97A82F79B) APIs.
 
 The Oracle R2DBC Driver has been verified with Oracle Database versions 18, 19,
 21, and 23.
@@ -209,7 +209,7 @@ are supported by Oracle R2DBC:
  - `PORT`
  - `DATABASE`
    - The database option is interpreted as the
-     [service name](https://docs.oracle.com/en/database/oracle/oracle-database/21/netag/identifying-and-accessing-database.html#GUID-153861C1-16AD-41EC-A179-074146B722E6)
+     [service name](https://docs.oracle.com/en/database/oracle/oracle-database/23/netag/identifying-and-accessing-database.html#GUID-153861C1-16AD-41EC-A179-074146B722E6)
       of an Oracle Database instance. _System Identifiers (SID) are not recognized_.
  - `USER`
  - `PASSWORD`
@@ -387,78 +387,80 @@ The next sections list Oracle JDBC connection properties which are supported by
 Oracle R2DBC.
 
 ##### TLS/SSL Connection Properties
-  - [oracle.net.tns_admin](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_TNS_ADMIN)
-  - [oracle.net.wallet_location](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_WALLET_LOCATION)
-  - [oracle.net.wallet_password](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_WALLET_PASSWORD)
-  - [javax.net.ssl.keyStore](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORE)
-  - [javax.net.ssl.keyStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTOREPASSWORD)
-  - [javax.net.ssl.keyStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORETYPE)
-  - [javax.net.ssl.trustStore](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORE)
-  - [javax.net.ssl.trustStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTOREPASSWORD)
-  - [javax.net.ssl.trustStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORETYPE)
-  - [oracle.net.authentication_services](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_SERVICES)
-  - [oracle.net.ssl_certificate_alias](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_CERTIFICATE_ALIAS)
-  - [oracle.net.ssl_server_dn_match](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_SERVER_DN_MATCH)
-  - [oracle.net.ssl_server_cert_dn](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_SERVER_CERT_DN)
-  - [oracle.net.ssl_version](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_VERSION)
-  - [oracle.net.ssl_cipher_suites](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_CIPHER_SUITES)
-  - [ssl.keyManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_KEYMANAGERFACTORY_ALGORITHM)
-  - [ssl.trustManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_TRUSTMANAGERFACTORY_ALGORITHM)
-  - [oracle.net.ssl_context_protocol](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_SSL_CONTEXT_PROTOCOL)
+  - [oracle.net.tns_admin](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_TNS_ADMIN)
+  - [oracle.net.wallet_location](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_WALLET_LOCATION)
+  - [oracle.net.wallet_password](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_WALLET_PASSWORD)
+  - [javax.net.ssl.keyStore](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORE)
+  - [javax.net.ssl.keyStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTOREPASSWORD)
+  - [javax.net.ssl.keyStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_KEYSTORETYPE)
+  - [javax.net.ssl.trustStore](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORE)
+  - [javax.net.ssl.trustStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTOREPASSWORD)
+  - [javax.net.ssl.trustStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_JAVAX_NET_SSL_TRUSTSTORETYPE)
+  - [oracle.net.authentication_services](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_SERVICES)
+  - [oracle.net.ssl_certificate_alias](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_CERTIFICATE_ALIAS)
+  - [oracle.net.ssl_server_dn_match](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_SERVER_DN_MATCH)
+  - [oracle.net.ssl_server_cert_dn](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_SERVER_CERT_DN)
+  - [oracle.net.ssl_version](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_VERSION)
+  - [oracle.net.ssl_cipher_suites](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_CIPHER_SUITES)
+  - [ssl.keyManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_KEYMANAGERFACTORY_ALGORITHM)
+  - [ssl.trustManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_SSL_TRUSTMANAGERFACTORY_ALGORITHM)
+  - [oracle.net.ssl_context_protocol](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_SSL_CONTEXT_PROTOCOL)
 
 ##### Miscellaneous Connection Properties
-  - [oracle.jdbc.fanEnabled](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_FAN_ENABLED)
-  - [oracle.jdbc.implicitStatementCacheSize](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_IMPLICIT_STATEMENT_CACHE_SIZE)
-  - [oracle.jdbc.defaultLobPrefetchSize](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_DEFAULT_LOB_PREFETCH_SIZE)
-  - [oracle.net.disableOob](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_NET_DISABLE_OUT_OF_BAND_BREAK)
-    - Out of band (OOB) breaks effect statement timeouts. Set this to "true" if statement timeouts are not working correctly.
-  - [oracle.jdbc.enableQueryResultCache](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_ENABLE_QUERY_RESULT_CACHE)
+  - [oracle.jdbc.fanEnabled](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_FAN_ENABLED)
+  - [oracle.jdbc.implicitStatementCacheSize](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_IMPLICIT_STATEMENT_CACHE_SIZE)
+  - [oracle.jdbc.defaultLobPrefetchSize](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_DEFAULT_LOB_PREFETCH_SIZE)
+  - [oracle.net.disableOob](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_THIN_NET_DISABLE_OUT_OF_BAND_BREAK)
+    - Out of band (OOB) breaks effect statement timeouts. Set this to "true" if
+      statement timeouts are not working correctly. OOB breaks are a
+    - [requirement for pipelining](#requirements-for-pipelining)
+  - [oracle.jdbc.enableQueryResultCache](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_ENABLE_QUERY_RESULT_CACHE)
     - Cached query results can cause phantom reads even if the serializable
       transaction isolation level is set. Set this to "false" if using the
       serializable isolation level.
-  - [oracle.jdbc.timezoneAsRegion](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_TIMEZONE_AS_REGION)
+  - [oracle.jdbc.timezoneAsRegion](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_TIMEZONE_AS_REGION)
     - Setting this option to "false" may resolve "ORA-01882: timezone region not
       found". The ORA-01882 error happens when Oracle Database doesn't recognize
       the name returned by `java.util.TimeZone.getDefault().getId()`.
 
 ##### Database Tracing Connection Properties
-  - [v$session.terminal](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_TERMINAL)
-  - [v$session.machine](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_MACHINE)
-  - [v$session.osuser](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_OSUSER)
-  - [v$session.program](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_PROGRAM)
-  - [v$session.process](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_PROCESS)
+  - [v$session.terminal](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_TERMINAL)
+  - [v$session.machine](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_MACHINE)
+  - [v$session.osuser](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_OSUSER)
+  - [v$session.program](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_PROGRAM)
+  - [v$session.process](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_VSESSION_PROCESS)
 
 ##### Oracle Net Encryption Connection Properties
-  - [oracle.net.encryption_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_LEVEL)
-  - [oracle.net.encryption_types_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_TYPES)
-  - [oracle.net.crypto_checksum_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_LEVEL)
-  - [oracle.net.crypto_checksum_types_client](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_TYPES)
+  - [oracle.net.encryption_client](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_LEVEL)
+  - [oracle.net.encryption_types_client](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_ENCRYPTION_TYPES)
+  - [oracle.net.crypto_checksum_client](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_LEVEL)
+  - [oracle.net.crypto_checksum_types_client](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_CHECKSUM_TYPES)
 
 ##### Kerberos Connection Properties
-  - [oracle.net.kerberos5_cc_name](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB5_CC_NAME)
-  - [oracle.net.kerberos5_mutual_authentication](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB5_MUTUAL)
-  - [oracle.net.KerberosRealm](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB_REALM)
-  - [oracle.net.KerberosJaasLoginModule](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB_JAAS_LOGIN_MODULE)
+  - [oracle.net.kerberos5_cc_name](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB5_CC_NAME)
+  - [oracle.net.kerberos5_mutual_authentication](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB5_MUTUAL)
+  - [oracle.net.KerberosRealm](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB_REALM)
+  - [oracle.net.KerberosJaasLoginModule](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB_JAAS_LOGIN_MODULE)
 
 ##### LDAP Connection Properties
-  - [oracle.net.ldap.security.authentication](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SECURITY_AUTHENTICATION)
-  - [oracle.net.ldap.security.principal](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SECURITY_PRINCIPAL)
-  - [oracle.net.ldap.security.credentials](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SECURITY_CREDENTIALS)
-  - [com.sun.jndi.ldap.connect.timeout](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_JNDI_LDAP_CONNECT_TIMEOUT)
-  - [com.sun.jndi.ldap.read.timeout](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_JNDI_LDAP_READ_TIMEOUT)
-  - [oracle.net.ldap.ssl.walletLocation](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_WALLET_LOCATION)
-  - [oracle.net.ldap.ssl.walletPassword](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_WALLET_PASSWORD)
-  - [oracle.net.ldap.ssl.keyStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYSTORE_TYPE)
-  - [oracle.net.ldap.ssl.keyStore](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYSTORE)
-  - [oracle.net.ldap.ssl.keyStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYSTORE_PASSWORD)
-  - [oracle.net.ldap.ssl.trustStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTSTORE_TYPE)
-  - [oracle.net.ldap.ssl.trustStore](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTSTORE)
-  - [oracle.net.ldap.ssl.trustStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTSTORE_PASSWORD)
-  - [oracle.net.ldap.ssl.supportedCiphers](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_CIPHER_SUITES)
-  - [oracle.net.ldap.ssl.supportedVersions](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_VERSIONS)
-  - [oracle.net.ldap.ssl.keyManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYMANAGER_FACTORY_ALGORITHM)
-  - [oracle.net.ldap.ssl.trustManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTMANAGER_FACTORY_ALGORITHM)
-  - [oracle.net.ldap.ssl.ssl_context_protocol](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_CONTEXT_PROTOCOL)
+  - [oracle.net.ldap.security.authentication](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SECURITY_AUTHENTICATION)
+  - [oracle.net.ldap.security.principal](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SECURITY_PRINCIPAL)
+  - [oracle.net.ldap.security.credentials](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SECURITY_CREDENTIALS)
+  - [com.sun.jndi.ldap.connect.timeout](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_JNDI_LDAP_CONNECT_TIMEOUT)
+  - [com.sun.jndi.ldap.read.timeout](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_JNDI_LDAP_READ_TIMEOUT)
+  - [oracle.net.ldap.ssl.walletLocation](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_WALLET_LOCATION)
+  - [oracle.net.ldap.ssl.walletPassword](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_WALLET_PASSWORD)
+  - [oracle.net.ldap.ssl.keyStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYSTORE_TYPE)
+  - [oracle.net.ldap.ssl.keyStore](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYSTORE)
+  - [oracle.net.ldap.ssl.keyStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYSTORE_PASSWORD)
+  - [oracle.net.ldap.ssl.trustStoreType](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTSTORE_TYPE)
+  - [oracle.net.ldap.ssl.trustStore](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTSTORE)
+  - [oracle.net.ldap.ssl.trustStorePassword](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTSTORE_PASSWORD)
+  - [oracle.net.ldap.ssl.supportedCiphers](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_CIPHER_SUITES)
+  - [oracle.net.ldap.ssl.supportedVersions](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_VERSIONS)
+  - [oracle.net.ldap.ssl.keyManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_KEYMANAGER_FACTORY_ALGORITHM)
+  - [oracle.net.ldap.ssl.trustManagerFactory.algorithm](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_TRUSTMANAGER_FACTORY_ALGORITHM)
+  - [oracle.net.ldap.ssl.ssl_context_protocol](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html#CONNECTION_PROPERTY_THIN_LDAP_SSL_CONTEXT_PROTOCOL)
 
 ### Thread Safety
 Oracle R2DBC's `ConnectionFactory` and `ConnectionFactoryProvider` are the only 
@@ -609,7 +611,7 @@ multiple subscribers.
 ### Errors and Warnings
 Oracle R2DBC creates R2dbcExceptions having the same ORA-XXXXX error codes 
 used by Oracle Database and Oracle JDBC. The
-[Database Error Messages](https://docs.oracle.com/en/database/oracle/oracle-database/21/errmg/ORA-00000.html#GUID-27437B7F-F0C3-4F1F-9C6E-6780706FB0F6)
+[Database Error Messages](https://docs.oracle.com/en/database/oracle/oracle-database/23/errmg/ORA-00000.html#GUID-27437B7F-F0C3-4F1F-9C6E-6780706FB0F6)
 document provides a reference for all ORA-XXXXX error codes.
 
 Warning messages from Oracle Database are emitted as 
@@ -688,7 +690,7 @@ generated values from basic forms of `INSERT` and `UPDATE` statements.
 
 If an empty set of column names is passed to `returnGeneratedValues`, the 
 `Statement` will return the
-[ROWID](https://docs.oracle.com/en/database/oracle/oracle-database/21/cncpt/tables-and-table-clusters.html#GUID-0258C4C2-2BF2-445F-B1E1-F282A57A6859)
+[ROWID](https://docs.oracle.com/en/database/oracle/oracle-database/23/cncpt/tables-and-table-clusters.html#GUID-0258C4C2-2BF2-445F-B1E1-F282A57A6859)
 of each row affected by an INSERT or UPDATE.
 > Programmers are advised not to use the ROWID as if it were a primary key.
 > The ROWID of a row change, or be reassigned to a different row.
@@ -730,10 +732,10 @@ This statement is not supported because it can not be written to include a
 > commands for which a RETURNING INTO clause is supported.
 > 
 > For the INSERT syntax, see:
-> https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/INSERT.html
+> https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/INSERT.html
 > 
 > For the UPDATE syntax, see:
-> https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/UPDATE.html
+> https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/UPDATE.html
 
 #### Procedural Calls
 The SQL string passed to ```Connection.createStatement(String)``` may execute a
@@ -772,11 +774,11 @@ types of Oracle Database.
 
 | Oracle SQL Type                                                                                                                                         | Java Type                                                     |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| [JSON](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-E441F541-BA31-4E8C-B7B4-D2FB8C42D0DF)                   | `javax.json.JsonObject` or `oracle.sql.json.OracleJsonObject` |
-| [DATE](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-5405B652-C30E-4F4F-9D33-9A4CB2110F1B)                   | `java.time.LocalDateTime`                                     |
-| [INTERVAL DAY TO SECOND](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-B03DD036-66F8-4BD3-AF26-6D4433EBEC1C) | `java.time.Duration`                                          |
-| [INTERVAL YEAR TO MONTH](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-ED59E1B3-BA8D-4711-B5C8-B0199C676A95) | `java.time.Period`                                            |
-| [SYS_REFCURSOR](https://docs.oracle.com/en/database/oracle/oracle-database/21/lnpls/static-sql.html#GUID-470A7A99-888A-46C2-BDAF-D4710E650F27)          | `io.r2dbc.spi.Result`                                         |
+| [JSON](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-E441F541-BA31-4E8C-B7B4-D2FB8C42D0DF)                   | `javax.json.JsonObject` or `oracle.sql.json.OracleJsonObject` |
+| [DATE](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-5405B652-C30E-4F4F-9D33-9A4CB2110F1B)                   | `java.time.LocalDateTime`                                     |
+| [INTERVAL DAY TO SECOND](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-B03DD036-66F8-4BD3-AF26-6D4433EBEC1C) | `java.time.Duration`                                          |
+| [INTERVAL YEAR TO MONTH](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-ED59E1B3-BA8D-4711-B5C8-B0199C676A95) | `java.time.Period`                                            |
+| [SYS_REFCURSOR](https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/static-sql.html#GUID-470A7A99-888A-46C2-BDAF-D4710E650F27)          | `io.r2dbc.spi.Result`                                         |
 > Unlike the standard SQL type named "DATE", the Oracle Database type named 
 > "DATE" stores values for year, month, day, hour, minute, and second. The 
 > standard SQL type only stores year, month, and day. LocalDateTime objects are able 
@@ -812,7 +814,7 @@ database calls. However, if the LOB value is larger than the prefetch size, then
 In a system that consumes very large LOBs, a very large amount of memory will be
 consumed if the entire LOB is prefetched. When a LOB is too large to be 
 prefetched entirely, a smaller prefetch size can be configured using the
-[oracle.jdbc.defaultLobPrefetchSize](https://docs.oracle.com/en/database/oracle/oracle-database/21/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_DEFAULT_LOB_PREFETCH_SIZE)
+[oracle.jdbc.defaultLobPrefetchSize](https://docs.oracle.com/en/database/oracle/oracle-database/23/jajdb/oracle/jdbc/OracleConnection.html?is-external=true#CONNECTION_PROPERTY_DEFAULT_LOB_PREFETCH_SIZE)
 option, and the LOB can be consumed as a stream. By mapping LOB columns to 
 `Blob` or `Clob` objects, the content can be consumed as a reactive stream. 
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <java.version>11</java.version>
-    <ojdbc.version>21.11.0.0</ojdbc.version>
+    <ojdbc.version>23.4.0.24.05</ojdbc.version>
     <r2dbc.version>1.0.0.RELEASE</r2dbc.version>
     <reactor.version>3.5.11</reactor.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>

--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -396,7 +396,6 @@ public final class OracleR2dbcOptions {
    */
   public static final Option<CharSequence> KERBEROS_JAAS_LOGIN_MODULE;
 
-
   /** The unmodifiable set of all extended options */
   private static final Set<Option<?>> OPTIONS = Set.of(
     DESCRIPTOR = Option.valueOf("oracle.r2dbc.descriptor"),

--- a/src/main/java/oracle/r2dbc/impl/AsyncLock.java
+++ b/src/main/java/oracle/r2dbc/impl/AsyncLock.java
@@ -37,7 +37,13 @@ import java.util.function.Function;
  * A lock that is acquired and unlocked asynchronously. An instance of this lock
  * is used to guard access to the Oracle JDBC Connection, without blocking
  * threads that contend for it.
- * </p><p>
+ * </p><p><i>
+ * Since the 23.1 release, Oracle JDBC no longer blocks threads during
+ * asynchronous calls. The remainder of this JavaDoc describes behavior which
+ * was present in 21.x releases of Oracle JDBC. If a 23.1 or newer version
+ * of Oracle JDBC is installed, then Oracle R2DBC will use the
+ * {@link NoOpAsyncLock} rather than {@link AsyncLockImpl}.
+ * </i></p><p>
  * Any time Oracle R2DBC invokes a synchronous API of Oracle JDBC, it will
  * acquire an instance of this lock before doing so. Synchronous method calls
  * will block a thread if JDBC has a database call in progress, and this can
@@ -90,83 +96,28 @@ import java.util.function.Function;
  * methods.
  * </p>
  */
-final class AsyncLock {
+public interface AsyncLock {
 
   /**
-   * Count that is incremented for invocation of {@link #lock(Runnable)}, and is
-   * decremented by each invocation of {@link #unlock()}. This lock is unlocked
-   * when the count is 0.
-   */
-  private final AtomicInteger waitCount = new AtomicInteger(0);
-
-  /**
-   * Dequeue of {@code Runnable} callbacks enqueued each time an invocation of
-   * {@link #lock(Runnable)} is not able to acquire this lock. The head of this
-   * dequeue is dequeued and executed by an invocation of {@link #unlock()}.
-   */
-  private final ConcurrentLinkedDeque<Runnable> waitQueue =
-    new ConcurrentLinkedDeque<>();
-
-  /**
-   * Acquires this lock, executes a {@code callback}, and then releases this 
-   * lock. The {@code callback} may be executed before this method returns
-   * if this lock is currently available. Otherwise, the {@code callback} is
+   * Acquires this lock, executes a {@code callback}, and then releases this
+   * lock. The {@code callback} may be executed before this method returns if
+   * this lock is currently available. Otherwise, the {@code callback} is
    * executed asynchronously after this lock becomes available.
+   *
    * @param callback Task to be executed with lock ownership. Not null.
    */
-  void lock(Runnable callback) {
-    assert waitCount.get() >= 0 : "Wait count is less than 0: " + waitCount;
-
-    // Acquire this lock and invoke the callback immediately, if possible
-    if (waitCount.compareAndSet(0, 1)) {
-      callback.run();
-    }
-    else {
-      // Enqueue the callback to be invoked asynchronously when this
-      // lock is unlocked
-      waitQueue.addLast(callback);
-
-      // Another thread may have unlocked this lock while this thread was
-      // enqueueing the callback. Dequeue and execute the head of the deque
-      // if this is the case.
-      if (0 == waitCount.getAndIncrement())
-        waitQueue.removeFirst().run();
-    }
-  }
-
-  void unlock() {
-    assert waitCount.get() > 0 : "Wait count is less than 1: " + waitCount;
-
-    // Decrement the count. Assuming that lock was called before this
-    // method, the count is guaranteed to be 1 or greater. If it greater
-    // than 1 after being decremented, then another invocation of lock has
-    // enqueued a callback
-    if (0 != waitCount.decrementAndGet())
-      waitQueue.removeFirst().run();
-  }
+  void lock(Runnable callback);
 
   /**
    * Returns a {@code Publisher} that acquires this lock and executes a
    * {@code jdbcRunnable} when a subscriber subscribes. The {@code Publisher}
    * emits {@code onComplete} if the runnable completes normally, or emits
    * {@code onError} if the runnable throws an exception.
+   *
    * @param jdbcRunnable Runnable to execute. Not null.
    * @return A publisher that emits the result of the {@code jdbcRunnable}.
    */
-  Publisher<Void> run(JdbcRunnable jdbcRunnable) {
-    return Mono.create(monoSink ->
-      lock(() -> {
-        try {
-          jdbcRunnable.runOrThrow();
-          unlock();
-          monoSink.success();
-        }
-        catch (Throwable throwable) {
-          unlock();
-          monoSink.error(throwable);
-        }
-      }));
-  }
+  Publisher<Void> run(JdbcRunnable jdbcRunnable);
 
   /**
    * Returns a {@code Publisher} that acquires this lock and executes a
@@ -174,24 +125,12 @@ final class AsyncLock {
    * emits {@code onNext} if the supplier returns a non-null value, and then
    * emits {@code onComplete}. Or, the {@code Publisher} emits {@code onError}
    * with any {@code Throwable} thrown by the supplier.
+   *
    * @param <T> The class of object output by the {@code jdbcSupplier}
    * @param jdbcSupplier Supplier to execute. Not null.
    * @return A publisher that emits the result of the {@code jdbcSupplier}.
    */
-  <T> Publisher<T> get(JdbcSupplier<T> jdbcSupplier) {
-    return Mono.create(monoSink ->
-      lock(() -> {
-        try {
-          T result = jdbcSupplier.getOrThrow();
-          unlock();
-          monoSink.success(result);
-        }
-        catch (Throwable throwable) {
-          unlock();
-          monoSink.error(throwable);
-        }
-      }));
-  }
+  <T> Publisher<T> get(JdbcSupplier<T> jdbcSupplier);
 
   /**
    * Returns a {@code Publisher} that acquires this lock and executes a
@@ -201,15 +140,13 @@ final class AsyncLock {
    * {@code null}, the returned publisher just emits {@code onComplete}. If the
    * supplier throws an error, the returned publisher emits that as
    * {@code onError}.
+   *
    * @param <T> The class of object emitted by the supplied publisher
    * @param publisherSupplier Supplier to execute. Not null.
    * @return A flat-mapping of the publisher output by the 
    * {@code publisherSupplier}.
    */
-  <T> Publisher<T> flatMap(JdbcSupplier<Publisher<T>> publisherSupplier) {
-    return Mono.from(get(publisherSupplier))
-      .flatMapMany(Function.identity());
-  }
+  <T> Publisher<T> flatMap(JdbcSupplier<Publisher<T>> publisherSupplier);
 
   /**
    * Returns a {@code Publisher} that proxies signals to and from a
@@ -223,318 +160,6 @@ final class AsyncLock {
    * @param publisher A publisher that uses the JDBC connection
    * @return A Publisher that
    */
-  <T> Publisher<T> lock(Publisher<T> publisher) {
-    return subscriber ->
-      lock(() ->
-        publisher.subscribe(new UsingConnectionSubscriber<>(subscriber)));
-  }
-
-  /**
-   * <p>
-   * A {@code Subscriber} that uses this {@link AsyncLock} to ensure that
-   * threads do not become blocked when contending for this adapter's JDBC
-   * {@code Connection}. Any time a {@code Subscriber} subscribes to a
-   * {@code Publisher} that uses the JDBC {@code Connection}, an instance of
-   * {@code UsingConnectionSubscriber} should be created in order to proxy
-   * signals between that {@code Publisher} and the downstream
-   * {@code Subscriber}.
-   * </p>
-   *
-   * <h3>Problem Overview</h3>
-   * <p>
-   * {@code UsingConnectionSubscriber} solves a problem with how Oracle JDBC
-   * implements thread safety. When an asynchronous database call is initiated
-   * with a {@code Connection}, that {@code Connection} is locked until
-   * the call completes. When a {@code Connection} is locked, any thread that
-   * invokes a method of that {@code Connection} or any object created by that
-   * {@code Connection} will become blocked. This can lead to a deadlock where
-   * all threads in a pool have become blocked until the database call
-   * completes, and JDBC can not complete the database call until a thread
-   * becomes unblocked.
-   * </p><p>
-   * As a simplified example, consider what would happen with the code below if
-   * the Executor had a pool of 1 thread:
-   * </p><pre>
-   * List<Flow.Publisher<Boolean>> publishers = new ArrayList<>();
-   * executor.execute(() -> {
-   *   try {
-   *     publishers.add(connection.prepareStatement("SELECT 0 FROM dual")
-   *       .unwrap(OraclePreparedStatement.class)
-   *       .executeAsyncOracle());
-   *
-   *     publishers.add(connection.prepareStatement("SELECT 1 FROM dual")
-   *       .unwrap(OraclePreparedStatement.class)
-   *       .executeAsyncOracle());
-   *   }
-   *   catch (SQLException sqlException) {
-   *     sqlException.printStackTrace();
-   *   }
-   * });
-   * </pre><p>
-   * After the first call to {@code executeAsyncOracle}, the connection is
-   * locked, and so when the second call to {@code executeAsyncOracle} is
-   * made, the executor thread is blocked. If Oracle JDBC is configured to use
-   * this same executor, which has a pool of just one thread, then no thread
-   * is left to handle the response from the database for the first call to
-   * {@code executeAsyncOracle}. With no thread available to handle the
-   * response, the call is never completed and the connection is never
-   * unlocked, so the code above results in a deadlock.
-   * </p><p>
-   * While the code above presents a somewhat obvious scenario, it is more
-   * common for deadlocks to occur in less obvious ways. Consider this code
-   * example which uses Project Reactor and R2DBC:
-   * </p><pre>
-   * Flux.usingWhen(
-   *   connectionFactory.create(),
-   *   connection ->
-   *     Flux.usingWhen(
-   *       Mono.from(connection.beginTransaction())
-   *         .thenReturn(connection),
-   *       connection ->
-   *         connection.createStatement("INSERT INTO deadlock VALUES(?)")
-   *           .bind(0, 0)
-   *           .execute(),
-   *       Connection::commitTransaction),
-   *   Connection::close)
-   *   .hasElements();
-   * </pre><p>
-   * The hasElements() operator transforms the sequence into a single boolean
-   * value. When an {@code onNext} signal delivers this value, the subscriber
-   * emits a {@code cancel} signal to the upstream publisher as the
-   * subscriber does not require any additional values. This cancel signal
-   * triggers a subscription to both the commitTransaction() publisher and to
-   * the close() publisher. The commitTransaction() publisher subscribed to
-   * first, and this has the Oracle JDBC connection locked until that
-   * database call completes. The close() publisher is subscribed to immediately
-   * afterwards, and this has the thread become blocked. As there is no
-   * thread left to handle the result of the commit, the connection never
-   * becomes unlocked.
-   * </p>
-   *
-   * <h3>Guarding Access to the JDBC Connection</h3>
-   * <p>
-   * Access to the JDBC Connection must be guarded such that no thread will
-   * attempt to use it when an asynchronous database call is in-flight. The
-   * potential for an in-flight call exists whenever there is a pending signal
-   * from the upstream {@code Publisher}. Instances of
-   * {@code UsingConnectionSubscriber} acquire this {@link AsyncLock}
-   * before requesting a signal from the publisher, and release the
-   * {@code asyncLock} once that signal is received. This ensures that no other
-   * thread will be able to acquire the {@code asyncLock} when a pending signal
-   * is potentially pending upon an asynchronous database call.
-   * </p><p>
-   * An {@code onSubscribe} signal is pending between an invocation of
-   * {@link Publisher#subscribe(Subscriber)} and an invocation of
-   * {@link Subscriber#onSubscribe(Subscription)}. Accordingly, the
-   * {@link AsyncLock} <i>MUST</i> be acquired before invoking
-   * {@code subscribe} with an instance of {@code UsingConnectionSubscriber}.
-   * When that instance receives an {@code onSubscribe} signal, it will release
-   * the {@code asyncLock}.
-   * </p><p>
-   * An {@code onNext} signal is pending between an invocation of
-   * {@link Subscription#request(long)} and a number of invocations of
-   * {@link Subscriber#onNext(Object)} equal to the number of
-   * values requested. Accordingly, instances of
-   * {@code UsingConnectionSubscriber} acquire the {@link AsyncLock} before
-   * emitting a {@code request} signal, and release the {@code asyncLock} when
-   * a corresponding number of {@code onNext} signals have been received.
-   * </p><p>
-   * When a {@code cancel} signal is emitted to the upstream {@code Publisher},
-   * that publisher will not emit any further signals to the downstream
-   * {@code Subscriber}. If an instance {@code UsingConnectionSubscriber}
-   * has acquired the {@link AsyncLock} for a pending {@code onNext} signal,
-   * then it will defer sending a {@code cancel} signal until the pending
-   * {@code onNext} signal has been received. Deferring cancellation until the
-   * the publisher invokes {@code onNext} ensures that the cancellation happens
-   * after any pending database call, and before any subsequent database calls
-   * that would obtain additional values for {@code onNext}.
-   * </p>
-   */
-  private final class UsingConnectionSubscriber<T>
-    implements Subscription, Subscriber<T> {
-
-    /**
-     * Value of {@link #demand} after a {@code cancel} signal has been received
-     * from the downstream subscriber, but before a pending {@code onNext}
-     * signal has been received.
-     */
-    private static final long CANCEL_PENDING = -1;
-
-    /**
-     * Value of {@link #demand} after a {@code cancel} signal has been received
-     * from the downstream subscriber, and after any pending {@code onNext}
-     * signal has been received, and after the {@code cancel} signal has been
-     * emitted to the upstream publisher.
-     */
-    private static final long TERMINATED = -2;
-
-    /** Downstream subscriber that requests values from database calls. */
-    private final Subscriber<T> downstream;
-
-    /**
-     * Subscription from an upstream publisher that emits values from database
-     * calls.
-     */
-    private Subscription upstream;
-
-    /**
-     * Unfilled demand from {@code request} signals. When the value is a
-     * positive number, it is equal to the number of pending {@code onNext}
-     * signals. When a {@code cancel} signal is received from downstream, the
-     * value is set to either {@link #CANCEL_PENDING} or
-     * {@link #TERMINATED}.
-     * if an {@code
-     * onNext}
-     * signal is
-     * pending, or it is set to {@link #TERMINATED} if no {@code onNext}
-     * signal is pending.
-     *
-     */
-    private final AtomicLong demand = new AtomicLong(0L);
-
-    private UsingConnectionSubscriber(Subscriber<T> downstream) {
-      this.downstream = downstream;
-    }
-
-    @Override
-    public void onSubscribe(Subscription subscription) {
-      unlock();
-      upstream = subscription;
-      downstream.onSubscribe(this);
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Acquires the lock before signalling a {@code request} upstream,
-     * where the request will increase demand from zero. Increasing demand
-     * from zero may initiate a database call from JDBC, so the lock must be
-     * acquired first.
-     * </p><p>
-     * The lock is released after {@code onNext} signals have decreased demand
-     * back to zero. Or, a terminal {@code onComplete/onError} signal may have
-     * the lock released before demand reaches zero.
-     * </p><p>
-     * If demand is increased from a number greater than zero, this
-     * indicates that the lock has already been acquired for a previous
-     * request, and that the lock can not be released until demand
-     * reaches zero. The request is sent upstream without reacquiring the
-     * lock in this case.
-     * </p><p>
-     * If demand is a negative number, this indicates that a terminal signal
-     * has already been received, either from upstream with
-     * {@code onComplete/onError}, or from downstream with {@code cancel}. In
-     * either case, the lock is not acquired and the request is not sent
-     * upstream; If this subscription is terminated, then there will be no
-     * future signals to unlock the lock.
-     * </p>
-     */
-    @Override
-    public void request(long n) {
-      lock(() -> {
-        long currentDemand = demand.getAndUpdate(current ->
-          current < 0L
-            ? current // Leave negative values as is
-            : (Long.MAX_VALUE - current) < n // Check for overflow
-              ? Long.MAX_VALUE
-              : current + n);
-
-        if (currentDemand >= 0)
-          upstream.request(n);
-        else //if (currentDemand == TERMINATED)
-          unlock();
-      });
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Decrements demand and releases the lock if it has reached zero. When
-     * demand is zero, there should be no active database calls from JDBC.
-     * </p><p>
-     * If a {@code cancel} signal has been received from downstream, but has
-     * not yet been sent upstream, then it will be sent from this method and
-     * the lock will be released. The upstream publisher should detect the
-     * cancel signal after it has called {@code onNext} on this subscriber, and
-     * and so it should cancel any future database calls.
-     * </p>
-     */
-    @Override
-    public void onNext(T value) {
-
-      long currentDemand = demand.getAndUpdate(current ->
-        current == Long.MAX_VALUE
-          ? current
-          : current == CANCEL_PENDING
-            ? TERMINATED
-            : current - 1L);
-
-      if (currentDemand == CANCEL_PENDING) {
-        unlock();
-        upstream.cancel();
-      }
-      else if (currentDemand > 0L) {
-
-        if (currentDemand == 1)
-          unlock();
-
-        downstream.onNext(value);
-      }
-      // else:
-      // Nothing is sent downstream if this subscription has been cancelled.
-
-    }
-
-    /**
-     * {@inheritDoc}
-     * <p>
-     * Defers sending the {@code cancel} upstream if an {@code onNext} signal
-     * is pending. If an {@code onNext} signal is pending, then there may be
-     * a database call in progress, and this subscriber must wait for that call
-     * to complete before releasing the lock. In this case, the demand is set
-     * to a negative value, and {@link #onNext(Object)} will detect this and
-     * send the {@code cancel} signal.
-     * </p><p>
-     * If no {@code onNext} signal is pending, then the {@code cancel} signal
-     * is sent upstream immediately.
-     * </p>
-     */
-    @Override
-    public void cancel() {
-      long currentDemand = demand.getAndUpdate(current ->
-        current > 0 || current == CANCEL_PENDING
-          ? CANCEL_PENDING
-          : TERMINATED);
-
-      if (currentDemand == 0)
-        upstream.cancel();
-
-    }
-
-    @Override
-    public void onError(Throwable error) {
-      terminate();
-      downstream.onError(error);
-    }
-
-    @Override
-    public void onComplete() {
-      terminate();
-      downstream.onComplete();
-    }
-
-    /**
-     * Terminates upon receiving {@code onComplete} or {@code onError}.
-     * Termination has this subscriber release the lock if it is currently
-     * being held. The {@link #demand} is updated so that no future request
-     * signals will have this subscriber acquire the lock again.
-     */
-    private void terminate() {
-      long currentDemand = demand.getAndSet(TERMINATED);
-
-      if (currentDemand > 0 || currentDemand == CANCEL_PENDING)
-        unlock();
-    }
-  }
+  <T> Publisher<T> lock(Publisher<T> publisher);
 
 }

--- a/src/main/java/oracle/r2dbc/impl/AsyncLockImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/AsyncLockImpl.java
@@ -1,0 +1,443 @@
+/*
+  Copyright (c) 2020, 2022, Oracle and/or its affiliates.
+
+  This software is dual-licensed to you under the Universal Permissive License
+  (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License
+  2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+  either license.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package oracle.r2dbc.impl;
+
+import oracle.r2dbc.impl.OracleR2dbcExceptions.JdbcRunnable;
+import oracle.r2dbc.impl.OracleR2dbcExceptions.JdbcSupplier;
+import org.reactivestreams.Publisher;
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.Mono;
+
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+
+/**
+ * Concrete implementation of {@link AsyncLock} for use with 21.x releases of
+ * Oracle JDBC.
+ */
+final class AsyncLockImpl implements AsyncLock {
+
+  /**
+   * Count that is incremented for invocation of {@link #lock(Runnable)}, and is
+   * decremented by each invocation of {@link #unlock()}. This lock is unlocked
+   * when the count is 0.
+   */
+  private final AtomicInteger waitCount = new AtomicInteger(0);
+
+  /**
+   * Dequeue of {@code Runnable} callbacks enqueued each time an invocation of
+   * {@link #lock(Runnable)} is not able to acquire this lock. The head of this
+   * dequeue is dequeued and executed by an invocation of {@link #unlock()}.
+   */
+  private final ConcurrentLinkedDeque<Runnable> waitQueue =
+    new ConcurrentLinkedDeque<>();
+
+  @Override
+  public void lock(Runnable callback) {
+    assert waitCount.get() >= 0 : "Wait count is less than 0: " + waitCount;
+
+    // Acquire this lock and invoke the callback immediately, if possible
+    if (waitCount.compareAndSet(0, 1)) {
+      callback.run();
+    }
+    else {
+      // Enqueue the callback to be invoked asynchronously when this
+      // lock is unlocked
+      waitQueue.addLast(callback);
+
+      // Another thread may have unlocked this lock while this thread was
+      // enqueueing the callback. Dequeue and execute the head of the deque
+      // if this is the case.
+      if (0 == waitCount.getAndIncrement())
+        waitQueue.removeFirst().run();
+    }
+  }
+
+  private void unlock() {
+    assert waitCount.get() > 0 : "Wait count is less than 1: " + waitCount;
+
+    // Decrement the count. Assuming that lock was called before this
+    // method, the count is guaranteed to be 1 or greater. If it greater
+    // than 1 after being decremented, then another invocation of lock has
+    // enqueued a callback
+    if (0 != waitCount.decrementAndGet())
+      waitQueue.removeFirst().run();
+  }
+
+  @Override
+  public Publisher<Void> run(JdbcRunnable jdbcRunnable) {
+    return Mono.create(monoSink ->
+      lock(() -> {
+        try {
+          jdbcRunnable.runOrThrow();
+          unlock();
+          monoSink.success();
+        }
+        catch (Throwable throwable) {
+          unlock();
+          monoSink.error(throwable);
+        }
+      }));
+  }
+
+  @Override
+  public <T> Publisher<T> get(JdbcSupplier<T> jdbcSupplier) {
+    return Mono.create(monoSink ->
+      lock(() -> {
+        try {
+          T result = jdbcSupplier.getOrThrow();
+          unlock();
+          monoSink.success(result);
+        }
+        catch (Throwable throwable) {
+          unlock();
+          monoSink.error(throwable);
+        }
+      }));
+  }
+
+  @Override
+  public <T> Publisher<T> flatMap(JdbcSupplier<Publisher<T>> publisherSupplier) {
+    return Mono.from(get(publisherSupplier))
+      .flatMapMany(Function.identity());
+  }
+
+  @Override
+  public <T> Publisher<T> lock(Publisher<T> publisher) {
+    return subscriber ->
+      lock(() ->
+        publisher.subscribe(new UsingConnectionSubscriber<>(subscriber)));
+  }
+
+  /**
+   * <p>
+   * A {@code Subscriber} that uses this {@link AsyncLockImpl} to ensure that
+   * threads do not become blocked when contending for this adapter's JDBC
+   * {@code Connection}. Any time a {@code Subscriber} subscribes to a
+   * {@code Publisher} that uses the JDBC {@code Connection}, an instance of
+   * {@code UsingConnectionSubscriber} should be created in order to proxy
+   * signals between that {@code Publisher} and the downstream
+   * {@code Subscriber}.
+   * </p>
+   *
+   * <h3>Problem Overview</h3>
+   * <p>
+   * {@code UsingConnectionSubscriber} solves a problem with how Oracle JDBC
+   * implements thread safety. When an asynchronous database call is initiated
+   * with a {@code Connection}, that {@code Connection} is locked until
+   * the call completes. When a {@code Connection} is locked, any thread that
+   * invokes a method of that {@code Connection} or any object created by that
+   * {@code Connection} will become blocked. This can lead to a deadlock where
+   * all threads in a pool have become blocked until the database call
+   * completes, and JDBC can not complete the database call until a thread
+   * becomes unblocked.
+   * </p><p>
+   * As a simplified example, consider what would happen with the code below if
+   * the Executor had a pool of 1 thread:
+   * </p><pre>
+   * List<Flow.Publisher<Boolean>> publishers = new ArrayList<>();
+   * executor.execute(() -> {
+   *   try {
+   *     publishers.add(connection.prepareStatement("SELECT 0 FROM dual")
+   *       .unwrap(OraclePreparedStatement.class)
+   *       .executeAsyncOracle());
+   *
+   *     publishers.add(connection.prepareStatement("SELECT 1 FROM dual")
+   *       .unwrap(OraclePreparedStatement.class)
+   *       .executeAsyncOracle());
+   *   }
+   *   catch (SQLException sqlException) {
+   *     sqlException.printStackTrace();
+   *   }
+   * });
+   * </pre><p>
+   * After the first call to {@code executeAsyncOracle}, the connection is
+   * locked, and so when the second call to {@code executeAsyncOracle} is
+   * made, the executor thread is blocked. If Oracle JDBC is configured to use
+   * this same executor, which has a pool of just one thread, then no thread
+   * is left to handle the response from the database for the first call to
+   * {@code executeAsyncOracle}. With no thread available to handle the
+   * response, the call is never completed and the connection is never
+   * unlocked, so the code above results in a deadlock.
+   * </p><p>
+   * While the code above presents a somewhat obvious scenario, it is more
+   * common for deadlocks to occur in less obvious ways. Consider this code
+   * example which uses Project Reactor and R2DBC:
+   * </p><pre>
+   * Flux.usingWhen(
+   *   connectionFactory.create(),
+   *   connection ->
+   *     Flux.usingWhen(
+   *       Mono.from(connection.beginTransaction())
+   *         .thenReturn(connection),
+   *       connection ->
+   *         connection.createStatement("INSERT INTO deadlock VALUES(?)")
+   *           .bind(0, 0)
+   *           .execute(),
+   *       Connection::commitTransaction),
+   *   Connection::close)
+   *   .hasElements();
+   * </pre><p>
+   * The hasElements() operator transforms the sequence into a single boolean
+   * value. When an {@code onNext} signal delivers this value, the subscriber
+   * emits a {@code cancel} signal to the upstream publisher as the
+   * subscriber does not require any additional values. This cancel signal
+   * triggers a subscription to both the commitTransaction() publisher and to
+   * the close() publisher. The commitTransaction() publisher subscribed to
+   * first, and this has the Oracle JDBC connection locked until that
+   * database call completes. The close() publisher is subscribed to immediately
+   * afterwards, and this has the thread become blocked. As there is no
+   * thread left to handle the result of the commit, the connection never
+   * becomes unlocked.
+   * </p>
+   *
+   * <h3>Guarding Access to the JDBC Connection</h3>
+   * <p>
+   * Access to the JDBC Connection must be guarded such that no thread will
+   * attempt to use it when an asynchronous database call is in-flight. The
+   * potential for an in-flight call exists whenever there is a pending signal
+   * from the upstream {@code Publisher}. Instances of
+   * {@code UsingConnectionSubscriber} acquire this {@link AsyncLockImpl}
+   * before requesting a signal from the publisher, and release the
+   * {@code asyncLock} once that signal is received. This ensures that no other
+   * thread will be able to acquire the {@code asyncLock} when a pending signal
+   * is potentially pending upon an asynchronous database call.
+   * </p><p>
+   * An {@code onSubscribe} signal is pending between an invocation of
+   * {@link Publisher#subscribe(Subscriber)} and an invocation of
+   * {@link Subscriber#onSubscribe(Subscription)}. Accordingly, the
+   * {@link AsyncLockImpl} <i>MUST</i> be acquired before invoking
+   * {@code subscribe} with an instance of {@code UsingConnectionSubscriber}.
+   * When that instance receives an {@code onSubscribe} signal, it will release
+   * the {@code asyncLock}.
+   * </p><p>
+   * An {@code onNext} signal is pending between an invocation of
+   * {@link Subscription#request(long)} and a number of invocations of
+   * {@link Subscriber#onNext(Object)} equal to the number of
+   * values requested. Accordingly, instances of
+   * {@code UsingConnectionSubscriber} acquire the {@link AsyncLockImpl} before
+   * emitting a {@code request} signal, and release the {@code asyncLock} when
+   * a corresponding number of {@code onNext} signals have been received.
+   * </p><p>
+   * When a {@code cancel} signal is emitted to the upstream {@code Publisher},
+   * that publisher will not emit any further signals to the downstream
+   * {@code Subscriber}. If an instance {@code UsingConnectionSubscriber}
+   * has acquired the {@link AsyncLockImpl} for a pending {@code onNext} signal,
+   * then it will defer sending a {@code cancel} signal until the pending
+   * {@code onNext} signal has been received. Deferring cancellation until the
+   * the publisher invokes {@code onNext} ensures that the cancellation happens
+   * after any pending database call, and before any subsequent database calls
+   * that would obtain additional values for {@code onNext}.
+   * </p>
+   */
+  private final class UsingConnectionSubscriber<T>
+    implements Subscription, Subscriber<T> {
+
+    /**
+     * Value of {@link #demand} after a {@code cancel} signal has been received
+     * from the downstream subscriber, but before a pending {@code onNext}
+     * signal has been received.
+     */
+    private static final long CANCEL_PENDING = -1;
+
+    /**
+     * Value of {@link #demand} after a {@code cancel} signal has been received
+     * from the downstream subscriber, and after any pending {@code onNext}
+     * signal has been received, and after the {@code cancel} signal has been
+     * emitted to the upstream publisher.
+     */
+    private static final long TERMINATED = -2;
+
+    /** Downstream subscriber that requests values from database calls. */
+    private final Subscriber<T> downstream;
+
+    /**
+     * Subscription from an upstream publisher that emits values from database
+     * calls.
+     */
+    private Subscription upstream;
+
+    /**
+     * Unfilled demand from {@code request} signals. When the value is a
+     * positive number, it is equal to the number of pending {@code onNext}
+     * signals. When a {@code cancel} signal is received from downstream, the
+     * value is set to either {@link #CANCEL_PENDING} or
+     * {@link #TERMINATED}.
+     * if an {@code
+     * onNext}
+     * signal is
+     * pending, or it is set to {@link #TERMINATED} if no {@code onNext}
+     * signal is pending.
+     *
+     */
+    private final AtomicLong demand = new AtomicLong(0L);
+
+    private UsingConnectionSubscriber(Subscriber<T> downstream) {
+      this.downstream = downstream;
+    }
+
+    @Override
+    public void onSubscribe(Subscription subscription) {
+      unlock();
+      upstream = subscription;
+      downstream.onSubscribe(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Acquires the lock before signalling a {@code request} upstream,
+     * where the request will increase demand from zero. Increasing demand
+     * from zero may initiate a database call from JDBC, so the lock must be
+     * acquired first.
+     * </p><p>
+     * The lock is released after {@code onNext} signals have decreased demand
+     * back to zero. Or, a terminal {@code onComplete/onError} signal may have
+     * the lock released before demand reaches zero.
+     * </p><p>
+     * If demand is increased from a number greater than zero, this
+     * indicates that the lock has already been acquired for a previous
+     * request, and that the lock can not be released until demand
+     * reaches zero. The request is sent upstream without reacquiring the
+     * lock in this case.
+     * </p><p>
+     * If demand is a negative number, this indicates that a terminal signal
+     * has already been received, either from upstream with
+     * {@code onComplete/onError}, or from downstream with {@code cancel}. In
+     * either case, the lock is not acquired and the request is not sent
+     * upstream; If this subscription is terminated, then there will be no
+     * future signals to unlock the lock.
+     * </p>
+     */
+    @Override
+    public void request(long n) {
+      lock(() -> {
+        long currentDemand = demand.getAndUpdate(current ->
+          current < 0L
+            ? current // Leave negative values as is
+            : (Long.MAX_VALUE - current) < n // Check for overflow
+              ? Long.MAX_VALUE
+              : current + n);
+
+        if (currentDemand >= 0)
+          upstream.request(n);
+        else //if (currentDemand == TERMINATED)
+          unlock();
+      });
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Decrements demand and releases the lock if it has reached zero. When
+     * demand is zero, there should be no active database calls from JDBC.
+     * </p><p>
+     * If a {@code cancel} signal has been received from downstream, but has
+     * not yet been sent upstream, then it will be sent from this method and
+     * the lock will be released. The upstream publisher should detect the
+     * cancel signal after it has called {@code onNext} on this subscriber, and
+     * and so it should cancel any future database calls.
+     * </p>
+     */
+    @Override
+    public void onNext(T value) {
+
+      long currentDemand = demand.getAndUpdate(current ->
+        current == Long.MAX_VALUE
+          ? current
+          : current == CANCEL_PENDING
+            ? TERMINATED
+            : current - 1L);
+
+      if (currentDemand == CANCEL_PENDING) {
+        unlock();
+        upstream.cancel();
+      }
+      else if (currentDemand > 0L) {
+
+        if (currentDemand == 1)
+          unlock();
+
+        downstream.onNext(value);
+      }
+      // else:
+      // Nothing is sent downstream if this subscription has been cancelled.
+
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Defers sending the {@code cancel} upstream if an {@code onNext} signal
+     * is pending. If an {@code onNext} signal is pending, then there may be
+     * a database call in progress, and this subscriber must wait for that call
+     * to complete before releasing the lock. In this case, the demand is set
+     * to a negative value, and {@link #onNext(Object)} will detect this and
+     * send the {@code cancel} signal.
+     * </p><p>
+     * If no {@code onNext} signal is pending, then the {@code cancel} signal
+     * is sent upstream immediately.
+     * </p>
+     */
+    @Override
+    public void cancel() {
+      long currentDemand = demand.getAndUpdate(current ->
+        current > 0 || current == CANCEL_PENDING
+          ? CANCEL_PENDING
+          : TERMINATED);
+
+      if (currentDemand == 0)
+        upstream.cancel();
+
+    }
+
+    @Override
+    public void onError(Throwable error) {
+      terminate();
+      downstream.onError(error);
+    }
+
+    @Override
+    public void onComplete() {
+      terminate();
+      downstream.onComplete();
+    }
+
+    /**
+     * Terminates upon receiving {@code onComplete} or {@code onError}.
+     * Termination has this subscriber release the lock if it is currently
+     * being held. The {@link #demand} is updated so that no future request
+     * signals will have this subscriber acquire the lock again.
+     */
+    private void terminate() {
+      long currentDemand = demand.getAndSet(TERMINATED);
+
+      if (currentDemand > 0 || currentDemand == CANCEL_PENDING)
+        unlock();
+    }
+  }
+
+}

--- a/src/main/java/oracle/r2dbc/impl/NoOpAsyncLock.java
+++ b/src/main/java/oracle/r2dbc/impl/NoOpAsyncLock.java
@@ -1,0 +1,61 @@
+/*
+  Copyright (c) 2020, 2021, Oracle and/or its affiliates.
+
+  This software is dual-licensed to you under the Universal Permissive License
+  (UPL) 1.0 as shown at https://oss.oracle.com/licenses/upl or Apache License
+  2.0 as shown at http://www.apache.org/licenses/LICENSE-2.0. You may choose
+  either license.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+package oracle.r2dbc.impl;
+
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+/**
+ * A no-op implementation of {@link AsyncLock} for use with 23.1 and newer
+ * versions of Oracle JDBC. All methods are implemented by immediately executing
+ * operations without acquiring a lock.
+ */
+final class NoOpAsyncLock implements AsyncLock {
+
+  @Override
+  public void lock(Runnable callback) {
+    callback.run();
+  }
+
+  @Override
+  public Publisher<Void> run(OracleR2dbcExceptions.JdbcRunnable jdbcRunnable) {
+    return Mono.fromRunnable(jdbcRunnable);
+  }
+
+  @Override
+  public <T> Publisher<T> get(
+    OracleR2dbcExceptions.JdbcSupplier<T> jdbcSupplier) {
+    return Mono.fromSupplier(jdbcSupplier);
+  }
+
+  @Override
+  public <T> Publisher<T> flatMap(
+    OracleR2dbcExceptions.JdbcSupplier<Publisher<T>> publisherSupplier) {
+    return Flux.defer(publisherSupplier);
+  }
+
+  @Override
+  public <T> Publisher<T> lock(Publisher<T> publisher) {
+    return publisher;
+  }
+}

--- a/src/main/java/oracle/r2dbc/impl/OracleBatchImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleBatchImpl.java
@@ -127,9 +127,6 @@ final class OracleBatchImpl implements Batch {
    * signals {@code onError} with {@code IllegalStateException} to any
    * subsequent subscribers.
    * </p>
-   * @implNote Oracle Database does not offer native support for batched
-   * execution of arbitrary SQL statements. This SPI method is implemented by
-   * individually executing each statement in this batch.
    */
   @Override
   public Publisher<OracleResultImpl> execute() {
@@ -137,7 +134,7 @@ final class OracleBatchImpl implements Batch {
     Queue<OracleStatementImpl> currentStatements = statements;
     statements = new LinkedList<>();
     return Flux.fromIterable(currentStatements)
-      .concatMap(OracleStatementImpl::execute);
+      .flatMapSequential(OracleStatementImpl::execute);
   }
 
 }

--- a/src/main/java/oracle/r2dbc/impl/ReactiveJdbcAdapter.java
+++ b/src/main/java/oracle/r2dbc/impl/ReactiveJdbcAdapter.java
@@ -535,7 +535,7 @@ interface ReactiveJdbcAdapter {
   Publisher<Void> publishClobFree(Clob clob) throws R2dbcException;
 
   /**
-   * Returns the {@link AsyncLock} that guards access to the JDBC
+   * Returns the {@link AsyncLockImpl} that guards access to the JDBC
    * {@link java.sql.Connection} created by this adapter (with
    * {@link #publishConnection(DataSource, Executor)}). This lock may be
    * acquired asynchronously, such that threads do not contend for the JDBC

--- a/src/test/java/oracle/r2dbc/impl/OracleBatchImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleBatchImplTest.java
@@ -98,7 +98,7 @@ public class OracleBatchImplTest {
           .add("SELECT 4 FROM sys.dual")
           .add("SELECT 5 FROM sys.dual")
           .execute())
-          .flatMap(result ->
+          .flatMapSequential(result ->
             result.map((row, metadata) -> row.get(0, Integer.class))));
 
     }

--- a/src/test/java/oracle/r2dbc/impl/OracleConnectionImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleConnectionImplTest.java
@@ -713,7 +713,7 @@ public class OracleConnectionImplTest {
           .add("SELECT 1 FROM dual")
           .add("SELECT 2 FROM dual")
           .execute())
-          .flatMap(result ->
+          .flatMapSequential(result ->
             result.map((row, metadata) -> row.get(0, Integer.class))));
     }
     finally {

--- a/src/test/java/oracle/r2dbc/impl/OracleResultImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleResultImplTest.java
@@ -47,6 +47,7 @@ import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static oracle.r2dbc.test.DatabaseConfig.connectTimeout;
+import static oracle.r2dbc.test.DatabaseConfig.jdbcVersion;
 import static oracle.r2dbc.test.DatabaseConfig.sharedConnection;
 import static oracle.r2dbc.test.DatabaseConfig.sqlTimeout;
 import static oracle.r2dbc.util.Awaits.awaitError;
@@ -662,8 +663,13 @@ public class OracleResultImplTest {
       Result.Segment secondSegment = segments.get(1);
       OracleR2dbcWarning warning =
         assertInstanceOf(OracleR2dbcWarning.class, secondSegment);
-      assertEquals(
-        warning.message(), "Warning: execution completed with warning");
+      String expectedMessage =
+        // Oracle JDBC includes more information in 23.3
+        jdbcVersion() == 21
+          ? "Warning: execution completed with warning"
+          : "Warning: ORA-17110: Execution completed with warning.\n" +
+              "https://docs.oracle.com/error-help/db/ora-17110/";
+      assertEquals(expectedMessage, warning.message());
       assertEquals(warning.errorCode(), 17110);
       assertEquals("99999", warning.sqlState()); // Default SQL state
       R2dbcException exception =

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -1395,8 +1395,8 @@ public class OracleStatementImplTest {
       // Result with one rows having the previous value. Expect the IN
       // parameter's default value to have been inserted by the call.
       consumeOne(connection.createStatement(
-        "BEGIN testMultiInOutCallAdd(?, :value2); END;")
-        .bind(0, Parameters.inOut(R2dbcType.NUMERIC, 2))
+        "BEGIN testMultiInOutCallAdd(:value1, :value2); END;")
+        .bind("value1", Parameters.inOut(R2dbcType.NUMERIC, 2))
         .bind("value2", Parameters.inOut(R2dbcType.NUMERIC, 102))
         .execute(),
         result ->
@@ -3167,8 +3167,7 @@ public class OracleStatementImplTest {
 
   /**
    * Connect to the database configured by {@link DatabaseConfig}, with a
-   * the connection configured to use a given {@code executor} for async
-   * callbacks.
+   * connection configured to use a given {@code executor} for async callbacks.
    * @param executor Executor for async callbacks
    * @return Connection that uses the {@code executor}
    */
@@ -3215,6 +3214,7 @@ public class OracleStatementImplTest {
    * @param connection Connection to verify
    */
   private void verifyConcurrentFetch(Connection connection) {
+    connection.setStatementTimeout(DatabaseConfig.sqlTimeout());
     try {
       awaitExecution(connection.createStatement(
         "CREATE TABLE testConcurrentFetch (value NUMBER)"));

--- a/src/test/java/oracle/r2dbc/test/DatabaseConfig.java
+++ b/src/test/java/oracle/r2dbc/test/DatabaseConfig.java
@@ -189,6 +189,20 @@ public final class DatabaseConfig {
   }
 
   /**
+   * Returns the major version number of the Oracle JDBC Driver installed as
+   * a service provider for java.sql.Driver.
+   * @return The major version number, such as 21 or 23.
+   */
+  public static int jdbcVersion() {
+    try {
+      return DriverManager.getDriver("jdbc:oracle:thin:").getMajorVersion();
+    }
+    catch (SQLException sqlException) {
+      throw new AssertionError(sqlException);
+    }
+  }
+
+  /**
    * Returns the options parsed from the "config.properties" resource.
    */
   public static ConnectionFactoryOptions connectionFactoryOptions() {


### PR DESCRIPTION
This branch updates the Oracle JDBC dependency to 23.4, and adds support for pipelined database calls. 

Changes in the README explain what pipelining is, what is required to use it.

The biggest change for the Oracle R2DBC code base is the use of AsyncLock. The 21.x releases of Oracle JDBC would block threads that attempted to make concurrent database calls. The AsyncLock was devised as a way to avoid this locking (and the possibility of dead-locking that came with it). The 23.4 release of Oracle JDBC does away with this locking. That was a key change required to support pipelining.

In this branch, AsyncLock becomes an interface with two concrete implementations:
1. AsyncLockImpl this is existing implementation of AsyncLock.
2. NoOpAsyncLock this is an implementation that does nothing.

Oracle R2DBC will now check the major version of Oracle JDBC at runtime, and then decide which AsyncLock it needs to use: 23 or newer? Then NoOpAsyncLock. Otherwise, AsyncLockImpl. 

Arguably, we could delete AsyncLock entirely. A strict dependency on 23.4 should mean that Oracle R2DBC no longer needs to support the older versions of Oracle JDBC. I've opted to leave support for the 21.x Oracle JDBC Driver in place for now. I think there may be some value for users in this, as it provides time for a transition from 21 to 23. The new 23 version has some changes which are known to break existing applications; In fact they broke some existing test cases for Oracle R2DBC (you can see the changes in this PR). Given that Oracle R2DBC was already designed to work the 21 driver, we can continue to support at almost no development cost. We will want to drop support for 21 at some point, but I see no need to rush.

A potentially performance impacting change has "zero copy IO" disabled by default. This is necessary to workaround a known issue where the database does not respond to pipelined calls that result in an error, and that use zero copy IO for bind values. Notably, zero copy IO is used for JSON and VECTOR bind values. Disabling this performance optimization seemed like a better option than not supporting pipelining, or not supporting JSON and VECTOR.