### PR TITLE
VECTOR Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,11 +668,12 @@ types of Oracle Database.
 
 | Oracle SQL Type                                                                                                                                         | Java Type                                                     |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| [JSON](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-E441F541-BA31-4E8C-B7B4-D2FB8C42D0DF)                   | `javax.json.JsonObject` or `oracle.sql.json.OracleJsonObject` |
-| [DATE](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-5405B652-C30E-4F4F-9D33-9A4CB2110F1B)                   | `java.time.LocalDateTime`                                     |
-| [INTERVAL DAY TO SECOND](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-B03DD036-66F8-4BD3-AF26-6D4433EBEC1C) | `java.time.Duration`                                          |
-| [INTERVAL YEAR TO MONTH](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/Data-Types.html#GUID-ED59E1B3-BA8D-4711-B5C8-B0199C676A95) | `java.time.Period`                                            |
-| [SYS_REFCURSOR](https://docs.oracle.com/en/database/oracle/oracle-database/21/lnpls/static-sql.html#GUID-470A7A99-888A-46C2-BDAF-D4710E650F27)          | `io.r2dbc.spi.Result`                                         |
+| [JSON](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-E441F541-BA31-4E8C-B7B4-D2FB8C42D0DF)                   | `javax.json.JsonObject` or `oracle.sql.json.OracleJsonObject` |
+| [DATE](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-5405B652-C30E-4F4F-9D33-9A4CB2110F1B)                   | `java.time.LocalDateTime`                                     |
+| [INTERVAL DAY TO SECOND](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-B03DD036-66F8-4BD3-AF26-6D4433EBEC1C) | `java.time.Duration`                                          |
+| [INTERVAL YEAR TO MONTH](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-ED59E1B3-BA8D-4711-B5C8-B0199C676A95) | `java.time.Period`                                            |
+| [SYS_REFCURSOR](https://docs.oracle.com/en/database/oracle/oracle-database/23/lnpls/static-sql.html#GUID-470A7A99-888A-46C2-BDAF-D4710E650F27)          | `io.r2dbc.spi.Result`                                         |
+| [VECTOR](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/Data-Types.html#GUID-801FFE49-217D-4012-9C55-66DAE1BA806F)                 | `double[]`, `float[]` or `byte[]`                             |
 > Unlike the standard SQL type named "DATE", the Oracle Database type named 
 > "DATE" stores values for year, month, day, hour, minute, and second. The 
 > standard SQL type only stores year, month, and day. LocalDateTime objects are able 

--- a/README.md
+++ b/README.md
@@ -962,6 +962,16 @@ Note that `double[]`, `float[]`, and `byte[]` can NOT be passed directly to
 `Statement.bind(int/String, Object)` when binding `VECTOR` data. The R2DBC 
 Specification defines `ARRAY` as the default mapping for Java arrays.
 
+A `VECTOR` column or OUT parameter is converted to `oracle.sql.VECTOR` by 
+default. The column or OUT parameter can also be converted to `double[]`, 
+`float[]`, or `byte[]` by passing the corresponding array class to the `get`
+methods:
+```java
+float[] getVector(io.r2dbc.Readable readable) {
+  return readable.get("vector", float[].class);
+}
+```
+
 #### Returning VECTOR from DML
 Returning a VECTOR column with `Statement.returningGeneratedValues(String...)`
 is not supported due to a defect in the 23.4 release of Oracle JDBC. Attempting

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
 
   <properties>
     <java.version>11</java.version>
-    <ojdbc.version>21.11.0.0</ojdbc.version>
+    <ojdbc.version>23.4.0.24.05</ojdbc.version>
     <r2dbc.version>1.0.0.RELEASE</r2dbc.version>
     <reactor.version>3.5.11</reactor.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>

--- a/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcTypes.java
@@ -104,6 +104,15 @@ public final class OracleR2dbcTypes {
     new TypeImpl(Result.class, "SYS_REFCURSOR");
 
   /**
+   * A vector of 64-bit floating point numbers, 32-bit floating point numbers,
+   * or 8-bit signed integers. Maps to <code>double[]</code> by default, as a
+   * <code>double</code> can store all the possible number formats without
+   * losing information.
+   */
+  public static final Type VECTOR =
+    new TypeImpl(oracle.sql.VECTOR.class, "VECTOR");
+
+  /**
    * <p>
    * Creates an {@link ArrayType} representing a user defined {@code ARRAY}
    * type. The {@code name} passed to this method must identify the name of a

--- a/src/main/java/oracle/r2dbc/impl/SqlTypeMap.java
+++ b/src/main/java/oracle/r2dbc/impl/SqlTypeMap.java
@@ -25,6 +25,7 @@ import io.r2dbc.spi.Type;
 import oracle.jdbc.OracleType;
 import oracle.r2dbc.OracleR2dbcObject;
 import oracle.r2dbc.OracleR2dbcTypes;
+import oracle.sql.VECTOR;
 import oracle.sql.json.OracleJsonObject;
 
 import java.math.BigDecimal;
@@ -85,6 +86,7 @@ final class SqlTypeMap {
       entry(JDBCType.NUMERIC, R2dbcType.NUMERIC),
       entry(JDBCType.NVARCHAR, R2dbcType.NVARCHAR),
       entry(JDBCType.REAL, R2dbcType.REAL),
+      entry(JDBCType.REF_CURSOR, OracleR2dbcTypes.REF_CURSOR),
       entry(JDBCType.ROWID, OracleR2dbcTypes.ROWID),
       entry(JDBCType.SMALLINT, R2dbcType.SMALLINT),
       entry(JDBCType.TIME, R2dbcType.TIME),
@@ -101,7 +103,7 @@ final class SqlTypeMap {
       entry(JDBCType.TINYINT, R2dbcType.TINYINT),
       entry(JDBCType.VARBINARY, R2dbcType.VARBINARY),
       entry(JDBCType.VARCHAR, R2dbcType.VARCHAR),
-      entry(JDBCType.REF_CURSOR, OracleR2dbcTypes.REF_CURSOR)
+      entry(OracleType.VECTOR, OracleR2dbcTypes.VECTOR)
     );
 
   /**
@@ -177,10 +179,13 @@ final class SqlTypeMap {
       entry(float[].class, JDBCType.ARRAY),
       entry(double[].class, JDBCType.ARRAY),
 
-      // Support binding OracleR2dbcReadable, Object[], and Map<String, Object>
-      // to OBJECT (ie: STRUCT)
+      // Support binding Map<String, Object> and OracleR2dbcObject to OBJECT
+      // (ie: STRUCT)
       entry(Map.class, JDBCType.STRUCT),
-      entry(OracleR2dbcObject.class, JDBCType.STRUCT)
+      entry(OracleR2dbcObject.class, JDBCType.STRUCT),
+
+      // Support binding oracle.sql.VECTOR to VECTOR
+      entry(VECTOR.class, OracleType.VECTOR)
     );
 
   /**
@@ -269,6 +274,7 @@ final class SqlTypeMap {
    *   <li>{@link Period} : INTERVAL YEAR TO MONTH</li>
    *   <li>{@link RowId} : ROWID</li>
    *   <li>{@link OracleJsonObject} : JSON</li>
+   *   <li>{@link oracle.sql.VECTOR} : VECTOR</li>
    * </ul>
    * @param javaType Java type to map
    * @return SQL type mapping for the {@code javaType}

--- a/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
+++ b/src/test/java/oracle/r2dbc/impl/OracleStatementImplTest.java
@@ -3281,6 +3281,8 @@ public class OracleStatementImplTest {
 
   @Test
   public void testVectorReturningExample() {
+    assumeTrue(databaseVersion() >= 23); // VECTOR is not added until 23.4
+
     Connection connection = awaitOne(sharedConnection());
     try {
       awaitExecution(connection.createStatement(

--- a/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
+++ b/src/test/java/oracle/r2dbc/impl/TypeMappingTest.java
@@ -34,6 +34,7 @@ import oracle.r2dbc.OracleR2dbcTypes;
 import oracle.r2dbc.OracleR2dbcTypes.ArrayType;
 import oracle.r2dbc.OracleR2dbcTypes.ObjectType;
 import oracle.r2dbc.test.TestUtils;
+import oracle.sql.VECTOR;
 import oracle.sql.json.OracleJsonFactory;
 import oracle.sql.json.OracleJsonObject;
 import org.junit.jupiter.api.Assertions;
@@ -45,6 +46,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.sql.RowId;
+import java.sql.SQLException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -63,6 +65,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
 import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -1520,6 +1523,77 @@ public class TypeMappingTest {
 
   }
 
+  /**
+   * <p>
+   * Verifies the implementation of Java to SQL and SQL to Java type mappings
+   * for the VECTOR data type. The R2DBC 1.0.0 Specification does not contain
+   * mapping guidelines for the VECTOR data type. The Oracle R2DBC Driver is
+   * expected to map VECTOR to a {@link oracle.sql.VECTOR} value.
+   *</p>
+   */
+  @Test
+  public void testVectorMapping() throws SQLException {
+
+    // The VECTOR data type was introduced in Oracle Database version 23ai, so
+    // this test is skipped if the version is older than 23.
+    assumeTrue(databaseVersion() >= 23,
+      "JSON columns are not supported by database versions older than 21");
+
+    Connection connection =
+      Mono.from(sharedConnection()).block(connectTimeout());
+    try {
+      double[] doubleArray =
+        DoubleStream.iterate(-2.0d, previous -> previous + 0.1d)
+          .limit(40)
+          .toArray();
+
+      // Expect VECTOR and oracle.sql.VECTOR to map.
+      VECTOR vector = VECTOR.ofFloat64Values(doubleArray);
+      verifyTypeMapping(connection, vector, "VECTOR");
+
+      // Expect VECTOR and double[] to map
+      verifyTypeMapping(
+        connection,
+        Parameters.in(OracleR2dbcTypes.VECTOR, doubleArray),
+        "VECTOR",
+        row ->
+          row.get(0, double[].class),
+        (ignored, actualValue) ->
+          assertArrayEquals(doubleArray, actualValue));
+
+      float[] floatArray = new float[doubleArray.length];
+      for (int i = 0; i < floatArray.length; i++)
+        floatArray[i] = (float) doubleArray[i];
+
+      // Expect VECTOR and float[] to map
+      verifyTypeMapping(
+        connection,
+        Parameters.in(OracleR2dbcTypes.VECTOR, floatArray),
+        "VECTOR",
+        row ->
+          row.get(0, float[].class),
+        (ignored, actualValue) ->
+          assertArrayEquals(floatArray, actualValue));
+
+      byte[] byteArray = new byte[doubleArray.length];
+      for (int i = 0; i < byteArray.length; i++)
+        byteArray[i] = (byte) doubleArray[i];
+
+      // Expect VECTOR and byte[] to map
+      verifyTypeMapping(
+        connection,
+        Parameters.in(OracleR2dbcTypes.VECTOR, byteArray),
+        "VECTOR",
+        row ->
+          row.get(0, byte[].class),
+        (ignored, actualValue) ->
+          assertArrayEquals(byteArray, actualValue));
+
+    }
+    finally {
+      tryAwaitNone(connection.close());
+    }
+  }
 
   /**
    * For an ARRAY type of a given {@code typeName}, verifies the following

--- a/src/test/java/oracle/r2dbc/test/DatabaseConfig.java
+++ b/src/test/java/oracle/r2dbc/test/DatabaseConfig.java
@@ -189,6 +189,34 @@ public final class DatabaseConfig {
   }
 
   /**
+   * Returns the major version number of the Oracle JDBC Driver installed as
+   * a service provider for java.sql.Driver.
+   * @return The major version number, such as 21 or 23.
+   */
+  public static int jdbcVersion() {
+    try {
+      return DriverManager.getDriver("jdbc:oracle:thin:").getMajorVersion();
+    }
+    catch (SQLException sqlException) {
+      throw new AssertionError(sqlException);
+    }
+  }
+
+  /**
+   * Returns the minor version number of the Oracle JDBC Driver installed as
+   * a service provider for java.sql.Driver.
+   * @return The major version number, such as 11 for 21.11, or 4 for 23.4.
+   */
+  public static int jdbcMinorVersion() {
+    try {
+      return DriverManager.getDriver("jdbc:oracle:thin:").getMinorVersion();
+    }
+    catch (SQLException sqlException) {
+      throw new AssertionError(sqlException);
+    }
+  }
+
+  /**
    * Returns the options parsed from the "config.properties" resource.
    */
   public static ConnectionFactoryOptions connectionFactoryOptions() {


### PR DESCRIPTION
This branch adds support for the VECTOR data type introduced in Oracle Database 23ai. It requires an update of the Oracle JDBC dependency to version 23.4.

Oracle R2DBC will use the oracle.sql.VECTOR class of Oracle JDBC as the default mapping for VECTOR data. This class provides conversions to and from numeric arrays, such as float[], so I think it will offer a good solution when integrating with ML libraries that also expose vectors as primitive numeric arrays.

Numeric arrays, such as `float[]` are already defined as a default mapping for `ARRAY` data. This default mapping appears in [Section 14.1 of the R2DBC Specification](https://r2dbc.io/spec/1.0.0.RELEASE/spec/html/#datatypes.mapping.collection). Also notable is that a `byte[]` would be mapped to a `RAW` by the underlying Oracle JDBC Driver. The need for oracle.sql.VECTOR as an intermediate mapping arises due to these existing mappings.

A new VECTOR type code is added to `OracleR2dbcTypes`. This type code is used by metadata classes to identify VECTOR data. This type code is also used to register OUT parameters. It can even be used for IN parameters, and this will allow users to directly bind primitive numeric arrays, without the need for an intermediate conversion to oracle.sql.VECTOR.

There is a known defect which will prevent `Statement.returningGeneratedValues(String...)` from returning VECTOR data. The defect will be resolved in the next release of Oracle JDBC. Strictly speaking, this means Oracle R2DBC does not fully support VECTOR, as it does not support the `returningGeneratedValues` method. But in all other cases, aside from returning values from DML, I think that almost-but-not-quite-full-support of VECTOR is valuable for our users. Users who need to return VECTOR from DML can use a temporary workaround which I've documented in the README.
