### PR TITLE
Fetch Size and Proxy Client Name Options

### DIFF
--- a/sample/src/main/java/oracle/r2dbc/samples/JdbcToR2dbc.java
+++ b/sample/src/main/java/oracle/r2dbc/samples/JdbcToR2dbc.java
@@ -26,7 +26,7 @@ import io.r2dbc.spi.ConnectionFactory;
 import io.r2dbc.spi.ConnectionFactoryOptions;
 import io.r2dbc.spi.R2dbcException;
 import io.r2dbc.spi.Result;
-import oracle.jdbc.pool.OracleDataSource;
+import oracle.jdbc.datasource.impl.OracleDataSource;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 
@@ -141,7 +141,8 @@ public final class JdbcToR2dbc {
    */
   static DataSource configureJdbc() throws SQLException {
 
-    OracleDataSource dataSource = new oracle.jdbc.pool.OracleDataSource();
+    OracleDataSource dataSource =
+      new oracle.jdbc.datasource.impl.OracleDataSource();
     dataSource.setDriverType("thin");
     dataSource.setServerName(DatabaseConfig.HOST);
     dataSource.setPortNumber(DatabaseConfig.PORT);

--- a/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
+++ b/src/main/java/oracle/r2dbc/OracleR2dbcOptions.java
@@ -396,6 +396,18 @@ public final class OracleR2dbcOptions {
    */
   public static final Option<CharSequence> KERBEROS_JAAS_LOGIN_MODULE;
 
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_DEFAULT_ROW_PREFETCH}
+   */
+  public static final Option<Integer> DEFAULT_FETCH_SIZE;
+
+  /**
+   * Configures the Oracle JDBC Connection used by Oracle R2DBC as specified by:
+   * {@link OracleConnection#CONNECTION_PROPERTY_PROXY_CLIENT_NAME}
+   */
+  public static final Option<CharSequence> PROXY_CLIENT_NAME;
+
   /** The unmodifiable set of all extended options */
   private static final Set<Option<?>> OPTIONS = Set.of(
     DESCRIPTOR = Option.valueOf("oracle.r2dbc.descriptor"),
@@ -509,7 +521,11 @@ public final class OracleR2dbcOptions {
     KERBEROS_REALM = Option.valueOf(
       OracleConnection.CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB_REALM),
     KERBEROS_JAAS_LOGIN_MODULE = Option.valueOf(
-      OracleConnection.CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB_JAAS_LOGIN_MODULE)
+      OracleConnection.CONNECTION_PROPERTY_THIN_NET_AUTHENTICATION_KRB_JAAS_LOGIN_MODULE),
+    DEFAULT_FETCH_SIZE = Option.valueOf(
+      OracleConnection.CONNECTION_PROPERTY_DEFAULT_ROW_PREFETCH),
+    PROXY_CLIENT_NAME = Option.valueOf(
+      OracleConnection.CONNECTION_PROPERTY_PROXY_CLIENT_NAME)
   );
 
   /**

--- a/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleReactiveJdbcAdapter.java
@@ -341,7 +341,7 @@ final class OracleReactiveJdbcAdapter implements ReactiveJdbcAdapter {
   public DataSource createDataSource(ConnectionFactoryOptions options) {
 
     OracleDataSource oracleDataSource =
-      fromJdbc(oracle.jdbc.pool.OracleDataSource::new);
+      fromJdbc(oracle.jdbc.datasource.impl.OracleDataSource::new);
 
     runJdbc(() -> oracleDataSource.setURL(composeJdbcUrl(options)));
     configureStandardOptions(oracleDataSource, options);
@@ -632,15 +632,14 @@ final class OracleReactiveJdbcAdapter implements ReactiveJdbcAdapter {
     // its effects. One effect is to have ResultSetMetaData describe
     // FLOAT columns as the FLOAT type, rather than the NUMBER type. This
     // effect allows the Oracle R2DBC Driver obtain correct metadata for
-    // FLOAT type columns. The property is deprecated, but the deprecation note
-    // explains that setting this to "false" is deprecated, and that it
-    // should be set to true; If not set, the 21c driver uses a default value
-    // of false.
-    @SuppressWarnings("deprecation")
-    String enableJdbcSpecCompliance =
-      OracleConnection.CONNECTION_PROPERTY_J2EE13_COMPLIANT;
+    // FLOAT type columns.
+    // The OracleConnection.CONNECTION_PROPERTY_J2EE13_COMPLIANT field is
+    // deprecated, so the String literal value of this field is used instead,
+    // just in case the field were to be removed in a future release of Oracle
+    // JDBC.
     runJdbc(() ->
-      oracleDataSource.setConnectionProperty(enableJdbcSpecCompliance, "true"));
+      oracleDataSource.setConnectionProperty(
+        "oracle.jdbc.J2EE13Compliant", "true"));
 
     // Cache PreparedStatements by default. The default value of the
     // OPEN_CURSORS parameter in the 21c and 19c databases is 50:

--- a/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleStatementImpl.java
@@ -597,8 +597,7 @@ final class OracleStatementImpl implements Statement {
     return adapter.getLock().get(() -> {
       PreparedStatement preparedStatement =
         jdbcConnection.prepareStatement(sql);
-      preparedStatement.setFetchSize(currentFetchSize);
-      preparedStatement.setQueryTimeout(timeout);
+      configureJdbcStatement(preparedStatement, currentFetchSize, timeout);
       return new JdbcStatement(preparedStatement, currentBinds);
     });
   }
@@ -629,8 +628,7 @@ final class OracleStatementImpl implements Statement {
     return adapter.getLock().get(() -> {
       PreparedStatement preparedStatement =
         jdbcConnection.prepareStatement(sql);
-      preparedStatement.setFetchSize(currentFetchSize);
-      preparedStatement.setQueryTimeout(timeout);
+      configureJdbcStatement(preparedStatement, currentFetchSize, timeout);
       return finalInvalidBinds == null
         ? new JdbcBatch(preparedStatement, currentBatch)
         : new JdbcBatchInvalidBinds(
@@ -649,8 +647,7 @@ final class OracleStatementImpl implements Statement {
 
     return adapter.getLock().get(() -> {
       CallableStatement callableStatement = jdbcConnection.prepareCall(sql);
-      callableStatement.setFetchSize(currentFetchSize);
-      callableStatement.setQueryTimeout(timeout);
+      configureJdbcStatement(callableStatement, currentFetchSize, timeout);
       return new JdbcCall(callableStatement, currentBinds, parameterNames);
     });
   }
@@ -671,10 +668,41 @@ final class OracleStatementImpl implements Statement {
         currentGeneratedColumns.length == 0
           ? jdbcConnection.prepareStatement(sql, RETURN_GENERATED_KEYS)
           : jdbcConnection.prepareStatement(sql, currentGeneratedColumns);
-      preparedStatement.setFetchSize(currentFetchSize);
-      preparedStatement.setQueryTimeout(timeout);
+      configureJdbcStatement(preparedStatement, currentFetchSize, timeout);
       return new JdbcReturningGenerated(preparedStatement, currentBinds);
     });
+  }
+
+  /**
+   * Configures a JDBC Statement with values that have been configured on an
+   * R2DBC Statement.
+   *
+   * @param statement The statement to configure. Not null.
+   *
+   * @param fetchSize Configuration of {@link #fetchSize(int)}, possibly 0 if
+   * a default size should be used.
+   *
+   * @param queryTimeout Configuration of {@link #timeout}, possibly 0 if no
+   * timeout should be used.
+   *
+   * @throws SQLException If the JDBC statement is closed.
+   */
+  private static void configureJdbcStatement(
+    java.sql.Statement statement, int fetchSize, int queryTimeout)
+    throws SQLException {
+
+    // It is noted that Oracle JDBC's feature of auto-tuning fetch sizes will
+    // be disabled if 0 is passed to setFetchSize. Perhaps similar behavior
+    // occurs with methods like setQueryTimeout as well? To be sure, don't call
+    // any methods unless non-default values are set.
+
+    if (fetchSize != 0) {
+      statement.setFetchSize(fetchSize);
+    }
+
+    if (queryTimeout != 0) {
+      statement.setQueryTimeout(queryTimeout);
+    }
   }
 
   /**

--- a/src/test/java/oracle/r2dbc/test/OracleTestKit.java
+++ b/src/test/java/oracle/r2dbc/test/OracleTestKit.java
@@ -93,7 +93,8 @@ public class OracleTestKit implements TestKit<Integer> {
   private final JdbcOperations jdbcOperations;
   {
     try {
-      OracleDataSource dataSource = new oracle.jdbc.pool.OracleDataSource();
+      OracleDataSource dataSource =
+        new oracle.jdbc.datasource.impl.OracleDataSource();
       dataSource.setURL(String.format("jdbc:oracle:thin:@%s%s:%d/%s",
         Optional.ofNullable(protocol())
           .map(protocol -> protocol + ":")


### PR DESCRIPTION
Added Options to configure JDBC with a default row prefetch, and a proxy client                                           
name.                                                                                                                     
                                                                                                                          
Added a test to make sure that Oracle R2DBC is actually passing option values                                             
  along to JDBC as connection properties.                                                                                 
                                                                                                                          
I noticed that JDBC disables fetch size tuning if set call setFetchSize(0) on                                             
  a Statement. Auto-tuning is a nice feature, so Oracle R2DBC won't call setFetchSize                                            
  anymore, unless a user passes a non-zero value to the fetchSize method of                                               
  an R2DBC Statement.                                                                                                     
                                                                                                                          
Replaced references to oracle.jdbc.pool.OracleDataSource with                                                             
  oracle.jdbc.datasource.impl.OracleDataSource.                                                                           
                                                                                                                          
Replaced references to the deprecated CONNECTION_PROPERTY_J2EE13_COMPLIANT field                                          
  of OracleConnection with the literal String value. Not sure if this field will                                          
  actually be removed at some point, but if that does happen then Oracle R2DBC                                            
  won't break because of it.                                                                                              
                                                                                                                          
Closes #147 and closes #154