### PR TITLE
JavaDoc and Code Clean Up for 1.3.0

### DIFF
--- a/src/main/java/oracle/r2dbc/impl/AsyncLock.java
+++ b/src/main/java/oracle/r2dbc/impl/AsyncLock.java
@@ -25,12 +25,6 @@ import oracle.r2dbc.impl.OracleR2dbcExceptions.JdbcSupplier;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
 import org.reactivestreams.Subscription;
-import reactor.core.publisher.Mono;
-
-import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
 
 /**
  * <p>
@@ -70,12 +64,6 @@ import java.util.function.Function;
  * immediately, before {@code lock(Runnable)} returns if the lock is
  * available. Otherwise, the {@code Runnable} is executed asynchronously
  * after the lock becomes available.
- * </p><p>
- * The {@code Runnable} provided to {@link #lock(Runnable)} <i>MUST</i> ensure
- * that a single invocation of {@link #unlock()} will occur after its
- * {@code run()} method is invoked. The call to {@code unlock} may occur
- * within the scope of the {@code Runnable.run()} method. It may also occur
- * asynchronously, after the {@code run()} method has returned.
  * </p>
  * <h3>Locking for Synchronous JDBC Calls</h3>
  * <p>
@@ -96,7 +84,7 @@ import java.util.function.Function;
  * methods.
  * </p>
  */
-public interface AsyncLock {
+interface AsyncLock {
 
   /**
    * Acquires this lock, executes a {@code callback}, and then releases this

--- a/src/main/java/oracle/r2dbc/impl/OracleBatchImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleBatchImpl.java
@@ -21,18 +21,15 @@
 
 package oracle.r2dbc.impl;
 
-import java.sql.Connection;
-import java.sql.Statement;
-import java.time.Duration;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.concurrent.atomic.AtomicReference;
-
 import io.r2dbc.spi.Batch;
 import io.r2dbc.spi.R2dbcException;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
+
+import java.sql.Connection;
+import java.time.Duration;
+import java.util.LinkedList;
+import java.util.Queue;
 
 import static oracle.r2dbc.impl.OracleR2dbcExceptions.requireNonNull;
 import static oracle.r2dbc.impl.OracleR2dbcExceptions.requireOpenConnection;
@@ -59,9 +56,6 @@ final class OracleBatchImpl implements Batch {
   /** The OracleConnectionImpl that created this Batch */
   private final OracleConnectionImpl r2dbcConnection;
 
-  /** Adapts Oracle JDBC Driver APIs into Reactive Streams APIs */
-  private final ReactiveJdbcAdapter adapter;
-
   /**
    * JDBC connection to an Oracle Database which executes this batch.
    */
@@ -83,14 +77,12 @@ final class OracleBatchImpl implements Batch {
    * SQL statements with a {@code jdbcConnection}.
    * @param timeout Timeout applied to each statement this batch executes.
    * Not null. Not negative.
-   * @param jdbcConnection JDBC connection to an Oracle Database. Not null.
-   * @param adapter Adapts JDBC calls into reactive streams. Not null.
+   * @param r2dbcConnection R2DBC connection that created this batch. Not null.
    */
   OracleBatchImpl(Duration timeout, OracleConnectionImpl r2dbcConnection) {
     this.timeout = timeout;
     this.r2dbcConnection = r2dbcConnection;
     this.jdbcConnection = r2dbcConnection.jdbcConnection();
-    this.adapter = r2dbcConnection.adapter();
   }
 
   /**

--- a/src/main/java/oracle/r2dbc/impl/OracleConnectionImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleConnectionImpl.java
@@ -411,6 +411,8 @@ final class OracleConnectionImpl implements Connection, Lifecycle {
    * publisher when there is no obligation to do so.
    * </p>
    *
+   * @param <T> the type of element signaled by the publisher.
+   *
    * @param publisher Publisher that must be subscribed to before closing the
    * JDBC connection. Not null.
    *

--- a/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
+++ b/src/main/java/oracle/r2dbc/impl/OracleResultImpl.java
@@ -268,7 +268,6 @@ abstract class OracleResultImpl implements Result {
    * statement which created the {@code ResultSet} to remain open until all
    * results are consumed.
    * @param resultSet {@code ResultSet} to publish. Not null.
-   * @param adapter Adapts JDBC calls into reactive streams. Not null.
    * @return A {@code Result} for a ResultSet
    */
   public static OracleResultImpl createQueryResult(
@@ -305,7 +304,6 @@ abstract class OracleResultImpl implements Result {
    * statement which created the {@code generatedKeys} {@code ResultSet} to
    * remain open until all results are consumed.
    * @param generatedKeys Generated values to publish. Not null.
-   * @param adapter Adapts JDBC calls into reactive streams. Not null.
    */
   static OracleResultImpl createGeneratedValuesResult(
     OracleConnectionImpl r2dbcConnection, long updateCount,


### PR DESCRIPTION
Final round of changes for a 1.3.0 release (hopefully):
- Fixed JavaDoc errors in several files.
- Removed unused imports in several files.
- Corrected accessibility level of AsyncLock interface. It should be package-private.
- Removed unused `adapter` field in OracleBatchImpl.
- Replaced decoding of INTERVALDS with new built-in `getDuration()` method