### PR TITLE
Revert "Bump org.springframework:spring-jdbc from 5.3.19 to 6.1.14"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <reactor.version>3.6.11</reactor.version>
     <reactive-streams.version>1.0.3</reactive-streams.version>
     <junit.version>5.9.1</junit.version>
-    <spring-jdbc.version>6.1.14</spring-jdbc.version>
+    <spring-jdbc.version>5.3.19</spring-jdbc.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
Reverts oracle/oracle-r2dbc#159

Before merging this change, we need to update the CI test action to use JDK 17 or newer. I'd like to revert the change until that happens. Otherwise, our CI tests will fail when other PR's are submitted.